### PR TITLE
Unify other library links with redis/redis-om-dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 **Redis OM Node.js** makes it easy to model Redis data in your Node.js applications.
 
-[Redis OM .NET][redis-om-dotnet] | **Redis OM Node.js** | [Redis OM Python][redis-om-python] | [Redis OM Spring][redis-om-spring]
+[Redis OM .NET](https://github.com/redis/redis-om-dotnet) | **Redis OM Node.js** | [Redis OM Spring](https://github.com/redis/redis-om-spring) | [Redis OM Python](https://github.com/redis/redis-om-python)
 
 <details>
   <summary><strong>Table of contents</strong></summary>


### PR DESCRIPTION
When browsing through the README, I noticed some of the links were based on an old code location, so I have updated those in this PR, and the PRs linked below for each repo:
redis/redis-om-dotnet#46
redis/redis-om-node#37
redis/redis-om-python/pull/95
redis/redis-om-spring#14