### PR TITLE
Fix Bug With Wildcard

### DIFF
--- a/lib/search/where-text.ts
+++ b/lib/search/where-text.ts
@@ -30,7 +30,7 @@ export default class WhereText<TEntity extends Entity> extends WhereField<TEntit
   }
 
   toString(): string {
-    let matchPunctuation = /[,.<>{}[\]"':;!@#$%^&*()\-+=~|]/g;
+    let matchPunctuation = /[,.<>{}[\]"':;!@#$%^&()\-+=~|]/g;
     let escapedValue = this.value.replace(matchPunctuation, '\\$&');
 
     if (this.exactValue) {


### PR DESCRIPTION
The wildcard would change from `*` to `/*`, making redis search for text with the character `*` instead of the wildcard.