### PR TITLE
Allow negative values for point coordinates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and Redis OM adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 - 2022-05-02
+### Fixed
+- Fixed error when reading `point` containing negative value from HASH.
 
 ## 0.3.0 - 2022-04-28
 ### Changed

--- a/lib/entity/fields/entity-point-field.ts
+++ b/lib/entity/fields/entity-point-field.ts
@@ -3,7 +3,7 @@ import EntityValue from "../entity-value";
 import Point from "../point";
 import { RedisHashData, RedisJsonData } from "../../client";
 
-const IS_COORD_PAIR = /^\d+(\.\d*)?,\d+(\.\d*)?$/;
+const IS_COORD_PAIR = /^-?\d+(\.\d*)?,-?\d+(\.\d*)?$/;
 
 class EntityPointField extends EntityField {
   toRedisJson(): RedisJsonData {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "redis-om",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "name": "redis-om",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "redis": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-om",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Object mapping, and more, for Redis and Node.js. Written in TypeScript.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/spec/helpers/example-data.ts
+++ b/spec/helpers/example-data.ts
@@ -36,11 +36,11 @@ export const A_POINT: Point = { longitude: 12.34, latitude: 56.78 };
 export const A_POINT_JSON: string = JSON.stringify(A_POINT);
 export const A_POINT_STRING: string = `${A_POINT.longitude},${A_POINT.latitude}`;
 
-export const ANOTHER_POINT: Point = { longitude: 23.45, latitude: 67.89 };
+export const ANOTHER_POINT: Point = { longitude: -23.45, latitude: 67.89 };
 export const ANOTHER_POINT_JSON: string = JSON.stringify(ANOTHER_POINT);
 export const ANOTHER_POINT_STRING: string = `${ANOTHER_POINT.longitude},${ANOTHER_POINT.latitude}`;
 
-export const A_THIRD_POINT: Point = { longitude: 34.56, latitude: 78.90 };
+export const A_THIRD_POINT: Point = { longitude: -34.56, latitude: 78.90 };
 export const A_THIRD_POINT_JSON: string = JSON.stringify(A_THIRD_POINT);
 export const A_THIRD_POINT_STRING: string = `${A_THIRD_POINT.longitude},${A_THIRD_POINT.latitude}`;
 


### PR DESCRIPTION
Point fields with negative values were incorrectly being rejected (when using hash storage) leading to an error when fetching data, e.g.:

    Non-point value of '-96.796988,32.776664' read from Redis for point field.

Updated regex to include optional `-` symbol