### PR TITLE
Store date as epoch in seconds, not milliseconds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,11 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and Redis OM adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.2 - 2022-05-03
+### Changed
+- *Breaking Change*: date values are stored in EPOCH seconds to align with [date/time APPLY functions](https://redis.io/docs/stack/search/reference/aggregations/#list-of-datetime-apply-functions)
+
+
 ## 0.3.1 - 2022-05-02
 ### Fixed
 - Fixed error when reading `point` containing negative value from HASH.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ When you create a `Schema`, it modifies the entity you handed it, adding getters
 
 The first three do exactly what you think—they define a property that is a [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), a [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), or a [Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean). `string[]` does what you'd think as well, specifically defining an [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of Strings.
 
-`date` is a little different, but still more or less what you'd expect. It defines a property that returns a [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) and can be set using not only a Date but also a String containing an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date or a number with the [UNIX epoch time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps) in *milliseconds*.
+`date` is a little different, but still more or less what you'd expect. It defines a property that returns a [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) and can be set using not only a Date but also a String containing an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date or a number with the [UNIX epoch time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps) in *seconds* (NOTE: the JavaScript Date object is specified in *milliseconds*).
 
 A `point` defines a point somewhere on the globe as a longitude and a latitude. It defines a property that returns and accepts a simple object with `longitude` and `latitude` properties. Like this:
 
@@ -657,12 +657,12 @@ albums = await albumRepository.search().where('outOfPublication').is.not.false()
 
 #### Searching on Dates
 
-If you have a field type of `date` in your schema, you can search on it using [Dates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formated strings, or the [UNIX epoch time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps) in *milliseconds*:
+If you have a field type of `date` in your schema, you can search on it using [Dates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formated strings, or the [UNIX epoch time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps) in *seconds*:
 
 ```javascript
 studios = await studioRepository.search().where('established').on(new Date('2010-12-27')).return.all()
 studios = await studioRepository.search().where('established').on('2010-12-27').return.all()
-studios = await studioRepository.search().where('established').on(1293408000000).return.all()
+studios = await studioRepository.search().where('established').on(1293408000).return.all()
 ```
 
 There are several date comparison methods to use. And they can be negated:

--- a/lib/entity/fields/entity-date-field.ts
+++ b/lib/entity/fields/entity-date-field.ts
@@ -21,7 +21,7 @@ class EntityDateField extends EntityField {
   }
 
   fromRedisHash(value: string) {
-    const parsed = Number.parseInt(value);
+    const parsed = Number.parseFloat(value);
     if (Number.isNaN(parsed)) throw Error(`Non-numeric value of '${value}' read from Redis for date field.`);
     const date = new Date();
     date.setTime(parsed * 1000);

--- a/lib/entity/fields/entity-date-field.ts
+++ b/lib/entity/fields/entity-date-field.ts
@@ -24,7 +24,7 @@ class EntityDateField extends EntityField {
     const parsed = Number.parseInt(value);
     if (Number.isNaN(parsed)) throw Error(`Non-numeric value of '${value}' read from Redis for date field.`);
     const date = new Date();
-    date.setTime(parsed);
+    date.setTime(parsed * 1000);
     this.value = date;
   }
 
@@ -41,7 +41,7 @@ class EntityDateField extends EntityField {
 
     if (this.isNumber(value)) {
       const newValue = new Date();
-      newValue.setTime(value as number);
+      newValue.setTime(value as number * 1000);
       return newValue;
     }
 
@@ -57,7 +57,7 @@ class EntityDateField extends EntityField {
   }
 
   private get valueAsNumber(): number {
-    return (this.value as Date).getTime();
+    return (this.value as Date).getTime() / 1000;
   }
 }
 

--- a/lib/search/where-date.ts
+++ b/lib/search/where-date.ts
@@ -78,8 +78,8 @@ export default class WhereDate<TEntity extends Entity> extends WhereField<TEntit
   }
 
   private coerceDateToEpoch(value: Date | number | string) {
-    if (value instanceof Date) return value.getTime();
-    if (typeof value === 'string') return new Date(value).getTime();
+    if (value instanceof Date) return value.getTime() / 1000;
+    if (typeof value === 'string') return new Date(value).getTime() / 1000;
     return value;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "redis-om",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redis-om",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "redis": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-om",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Object mapping, and more, for Redis and Node.js. Written in TypeScript.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/spec/functional/helpers/data-helper.ts
+++ b/spec/functional/helpers/data-helper.ts
@@ -82,7 +82,7 @@ export async function loadTestHash(client: Client, key: string, data: SampleEnti
       else if (typeof value === 'number') command.push(field, value.toString());
       else if (typeof value === 'string') command.push(field, value);
       else if (Array.isArray(value)) command.push(field, value.join('|'));
-      else if (value instanceof Date) command.push(field, value.getTime().toString());
+      else if (value instanceof Date) command.push(field, (value.getTime() / 1000).toString());
       else if (typeof value === 'object') command.push(field, `${value.longitude},${value.latitude}`)
     }
   })
@@ -97,7 +97,7 @@ export async function loadTestJson(client: Client, key: string, data: SampleEnti
   Object.keys(data).forEach(field => {
     const value = (data as any)[field];
     if (value !== null) {
-      if (value instanceof Date) json[field] = value.getTime();
+      if (value instanceof Date) json[field] = value.getTime() / 1000;
       else if (typeof value === 'object' && !Array.isArray(value)) json[field] = `${value.longitude},${value.latitude}`;
       else json[field] = value;
     }

--- a/spec/helpers/example-data.ts
+++ b/spec/helpers/example-data.ts
@@ -19,17 +19,17 @@ export const A_THIRD_NUMBER_STRING = A_THIRD_NUMBER.toString();
 
 export const A_DATE: Date = new Date('1997-07-04T16:56:55.000Z');
 export const A_DATE_ISO: string = A_DATE.toISOString();
-export const A_DATE_EPOCH: number = A_DATE.getTime();
+export const A_DATE_EPOCH: number = A_DATE.getTime() / 1000;
 export const A_DATE_EPOCH_STRING: string = A_DATE_EPOCH.toString();
 
 export const ANOTHER_DATE: Date = new Date('1969-07-20T20:17:40.000Z');
 export const ANOTHER_DATE_ISO: string = ANOTHER_DATE.toISOString();
-export const ANOTHER_DATE_EPOCH: number = ANOTHER_DATE.getTime();
+export const ANOTHER_DATE_EPOCH: number = ANOTHER_DATE.getTime() / 1000;
 export const ANOTHER_DATE_EPOCH_STRING: string = ANOTHER_DATE_EPOCH.toString();
 
 export const A_THIRD_DATE: Date = new Date('2015-07-14T11:49:57.000Z');
 export const A_THIRD_DATE_ISO: string = A_THIRD_DATE.toISOString();
-export const A_THIRD_DATE_EPOCH: number = A_THIRD_DATE.getTime();
+export const A_THIRD_DATE_EPOCH: number = A_THIRD_DATE.getTime() / 1000;
 export const A_THIRD_DATE_EPOCH_STRING: string = A_THIRD_DATE_EPOCH.toString();
 
 export const A_POINT: Point = { longitude: 12.34, latitude: 56.78 };

--- a/spec/helpers/example-data.ts
+++ b/spec/helpers/example-data.ts
@@ -17,7 +17,7 @@ export const ANOTHER_NUMBER_STRING = ANOTHER_NUMBER.toString();
 export const A_THIRD_NUMBER = 13;
 export const A_THIRD_NUMBER_STRING = A_THIRD_NUMBER.toString();
 
-export const A_DATE: Date = new Date('1997-07-04T16:56:55.000Z');
+export const A_DATE: Date = new Date('1997-07-04T16:56:55.456Z');
 export const A_DATE_ISO: string = A_DATE.toISOString();
 export const A_DATE_EPOCH: number = A_DATE.getTime() / 1000;
 export const A_DATE_EPOCH_STRING: string = A_DATE_EPOCH.toString();


### PR DESCRIPTION
My attempts at using [date/time APPLY functions](https://redis.io/docs/stack/search/reference/aggregations/#list-of-datetime-apply-functions) in aggregate searches were failing and I'm thinking it's due to the dates being stored as _milliseconds_ instead of _seconds_.

So this scales the JavaScript Date values when converting to and from Redis using `.getTime()` and `.setTime()` (which work in milliseconds).

Let me know if my understanding is correct and I'll update the changelog / version again.