### PR TITLE
Remove unnecessary `toRedisHash` (repeated call)

### DIFF
--- a/lib/repository/index.ts
+++ b/lib/repository/index.ts
@@ -225,7 +225,7 @@ export class HashRepository<TEntity extends Entity> extends Repository<TEntity> 
       await this.client.unlink(entity.keyName);
       return;
     }
-    await this.client.hsetall(entity.keyName, entity.toRedisHash());
+    await this.client.hsetall(entity.keyName, data);
   }
 
   protected async readEntities(ids: string[]): Promise<TEntity[]> {


### PR DESCRIPTION
I noticed while working on the vector similarity that `entity.toRedisHash()` calls are doubled up in the `HashRepository`