### PR TITLE
Fixing double CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
+    branches: ["main"]
   pull_request:
+    branches: ["main"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Prior to this change, a pull request would trigger two CI runs, due to the push and pull_request settings being unqualified. After this, merges to main will run a full CI suite, as will any pull request (or subsequent pushes to a PR), made against the main branch