### PR TITLE
Fixing failing build

### DIFF
--- a/spec/functional/search/search-hash.spec.ts
+++ b/spec/functional/search/search-hash.spec.ts
@@ -52,10 +52,10 @@ describe("search for hashes", () => {
 
     expect(entities).toHaveLength(4);
     expect(entities).toEqual([
-      expect.objectContaining({ entityId: '4', ...AN_ESCAPED_ENTITY }),
       expect.objectContaining({ entityId: '3', ...A_THIRD_ENTITY }),
       expect.objectContaining({ entityId: '2', ...ANOTHER_ENTITY }),
-      expect.objectContaining({ entityId: '1', ...AN_ENTITY })
+      expect.objectContaining({ entityId: '1', ...AN_ENTITY }),
+      expect.objectContaining({ entityId: '4', ...AN_ESCAPED_ENTITY })
     ]);
   });
 

--- a/spec/functional/search/search-json.spec.ts
+++ b/spec/functional/search/search-json.spec.ts
@@ -52,10 +52,10 @@ describe("search for JSON documents", () => {
 
     expect(entities).toHaveLength(4);
     expect(entities).toEqual([
-      expect.objectContaining({ entityId: '4', ...AN_ESCAPED_ENTITY }),
       expect.objectContaining({ entityId: '3', ...A_THIRD_ENTITY }),
       expect.objectContaining({ entityId: '2', ...ANOTHER_ENTITY }),
       expect.objectContaining({ entityId: '1', ...AN_ENTITY }),
+      expect.objectContaining({ entityId: '4', ...AN_ESCAPED_ENTITY })
     ]);
   });
 


### PR DESCRIPTION
RediSearch used to put nulls first, now it puts nulls lasts. Updated tests to reflect this.