### PR TITLE
Fix for latest RediSearch + JSON

### DIFF
--- a/spec/functional/search/create-and-drop-index-on-hash.spec.ts
+++ b/spec/functional/search/create-and-drop-index-on-hash.spec.ts
@@ -5,6 +5,23 @@ import { Repository } from '$lib/repository';
 import { SampleHashEntity, createHashEntitySchema } from '../helpers/data-helper';
 import { fetchIndexHash, fetchIndexInfo, removeAll } from '../helpers/redis-helper';
 
+const expected = [
+  ['identifier', 'aString', 'attribute', 'aString', 'type', 'TAG', 'SEPARATOR', '|'],
+  ['identifier', 'anotherString', 'attribute', 'anotherString', 'type', 'TAG', 'SEPARATOR', '|'],
+  ['identifier', 'someText', 'attribute', 'someText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
+  ['identifier', 'someOtherText', 'attribute', 'someOtherText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
+  ['identifier', 'aNumber', 'attribute', 'aNumber', 'type', 'NUMERIC', 'SORTABLE'],
+  ['identifier', 'anotherNumber', 'attribute', 'anotherNumber', 'type', 'NUMERIC', 'SORTABLE'],
+  ['identifier', 'aBoolean', 'attribute', 'aBoolean', 'type', 'TAG', 'SEPARATOR', ','],
+  ['identifier', 'anotherBoolean', 'attribute', 'anotherBoolean', 'type', 'TAG', 'SEPARATOR', ','],
+  ['identifier', 'aPoint', 'attribute', 'aPoint', 'type', 'GEO'],
+  ['identifier', 'anotherPoint', 'attribute', 'anotherPoint', 'type', 'GEO'],
+  ['identifier', 'aDate', 'attribute', 'aDate', 'type', 'NUMERIC', 'SORTABLE'],
+  ['identifier', 'anotherDate', 'attribute', 'anotherDate', 'type', 'NUMERIC', 'SORTABLE'],
+  ['identifier', 'someStrings', 'attribute', 'someStrings', 'type', 'TAG', 'SEPARATOR', '|'],
+  ['identifier', 'someOtherStrings', 'attribute', 'someOtherStrings', 'type', 'TAG', 'SEPARATOR', '|']
+]
+
 describe("create and drop index on hash", () => {
 
   let client: Client;
@@ -57,22 +74,7 @@ describe("create and drop index on hash", () => {
     it("has the expected fields", () => {
       let fields = indexInfo[7];
       expect(fields).toHaveLength(14);
-      expect(fields).toEqual([
-        ['identifier', 'aString', 'attribute', 'aString', 'type', 'TAG', 'SEPARATOR', '|'],
-        ['identifier', 'anotherString', 'attribute', 'anotherString', 'type', 'TAG', 'SEPARATOR', '|'],
-        ['identifier', 'someText', 'attribute', 'someText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
-        ['identifier', 'someOtherText', 'attribute', 'someOtherText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
-        ['identifier', 'aNumber', 'attribute', 'aNumber', 'type', 'NUMERIC', 'SORTABLE'],
-        ['identifier', 'anotherNumber', 'attribute', 'anotherNumber', 'type', 'NUMERIC', 'SORTABLE'],
-        ['identifier', 'aBoolean', 'attribute', 'aBoolean', 'type', 'TAG', 'SEPARATOR', ','],
-        ['identifier', 'anotherBoolean', 'attribute', 'anotherBoolean', 'type', 'TAG', 'SEPARATOR', ','],
-        ['identifier', 'aPoint', 'attribute', 'aPoint', 'type', 'GEO'],
-        ['identifier', 'anotherPoint', 'attribute', 'anotherPoint', 'type', 'GEO'],
-        ['identifier', 'aDate', 'attribute', 'aDate', 'type', 'NUMERIC', 'SORTABLE'],
-        ['identifier', 'anotherDate', 'attribute', 'anotherDate', 'type', 'NUMERIC', 'SORTABLE'],
-        ['identifier', 'someStrings', 'attribute', 'someStrings', 'type', 'TAG', 'SEPARATOR', '|'],
-        ['identifier', 'someOtherStrings', 'attribute', 'someOtherStrings', 'type', 'TAG', 'SEPARATOR', '|']
-      ]);
+      expect(fields).toEqual(expected);
     });
 
     describe("and then the index is dropped", () => {
@@ -108,22 +110,7 @@ describe("create and drop index on hash", () => {
         expect(indexHash).toBe("ryZTksm66ndOWrltH5b2z8u8BgI=");
 
         expect(fields).toHaveLength(14);
-        expect(fields).toEqual([
-          ['identifier', 'aString', 'attribute', 'aString', 'type', 'TAG', 'SEPARATOR', '|'],
-          ['identifier', 'anotherString', 'attribute', 'anotherString', 'type', 'TAG', 'SEPARATOR', '|'],
-          ['identifier', 'someText', 'attribute', 'someText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
-          ['identifier', 'someOtherText', 'attribute', 'someOtherText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
-          ['identifier', 'aNumber', 'attribute', 'aNumber', 'type', 'NUMERIC', 'SORTABLE'],
-          ['identifier', 'anotherNumber', 'attribute', 'anotherNumber', 'type', 'NUMERIC', 'SORTABLE'],
-          ['identifier', 'aBoolean', 'attribute', 'aBoolean', 'type', 'TAG', 'SEPARATOR', ','],
-          ['identifier', 'anotherBoolean', 'attribute', 'anotherBoolean', 'type', 'TAG', 'SEPARATOR', ','],
-          ['identifier', 'aPoint', 'attribute', 'aPoint', 'type', 'GEO'],
-          ['identifier', 'anotherPoint', 'attribute', 'anotherPoint', 'type', 'GEO'],
-          ['identifier', 'aDate', 'attribute', 'aDate', 'type', 'NUMERIC', 'SORTABLE'],
-          ['identifier', 'anotherDate', 'attribute', 'anotherDate', 'type', 'NUMERIC', 'SORTABLE'],
-          ['identifier', 'someStrings', 'attribute', 'someStrings', 'type', 'TAG', 'SEPARATOR', '|'],
-          ['identifier', 'someOtherStrings', 'attribute', 'someOtherStrings', 'type', 'TAG', 'SEPARATOR', '|']
-        ]);
+        expect(fields).toEqual(expected);
       });
     });
 

--- a/spec/functional/search/create-and-drop-index-on-json.spec.ts
+++ b/spec/functional/search/create-and-drop-index-on-json.spec.ts
@@ -5,6 +5,23 @@ import { Repository } from '$lib/repository';
 import { SampleJsonEntity, createJsonEntitySchema } from '../helpers/data-helper';
 import { fetchIndexHash, fetchIndexInfo, removeAll } from '../helpers/redis-helper';
 
+const expected = [
+  ['identifier', '$.aString', 'attribute', 'aString', 'type', 'TAG', 'SEPARATOR', '|'],
+  ['identifier', '$.anotherString', 'attribute', 'anotherString', 'type', 'TAG', 'SEPARATOR', '|'],
+  ['identifier', '$.someText', 'attribute', 'someText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE', 'UNF'],
+  ['identifier', '$.someOtherText', 'attribute', 'someOtherText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE', 'UNF'],
+  ['identifier', '$.aNumber', 'attribute', 'aNumber', 'type', 'NUMERIC', 'SORTABLE', 'UNF'],
+  ['identifier', '$.anotherNumber', 'attribute', 'anotherNumber', 'type', 'NUMERIC', 'SORTABLE', 'UNF'],
+  ['identifier', '$.aBoolean', 'attribute', 'aBoolean', 'type', 'TAG', 'SEPARATOR', ''],
+  ['identifier', '$.anotherBoolean', 'attribute', 'anotherBoolean', 'type', 'TAG', 'SEPARATOR', ''],
+  ['identifier', '$.aPoint', 'attribute', 'aPoint', 'type', 'GEO'],
+  ['identifier', '$.anotherPoint', 'attribute', 'anotherPoint', 'type', 'GEO'],
+  ['identifier', '$.aDate', 'attribute', 'aDate', 'type', 'NUMERIC', 'SORTABLE', 'UNF'],
+  ['identifier', '$.anotherDate', 'attribute', 'anotherDate', 'type', 'NUMERIC', 'SORTABLE', 'UNF'],
+  ['identifier', '$.someStrings[*]', 'attribute', 'someStrings', 'type', 'TAG', 'SEPARATOR', '|'],
+  ['identifier', '$.someOtherStrings[*]', 'attribute', 'someOtherStrings', 'type', 'TAG', 'SEPARATOR', '|']
+]
+
 describe("create and drop index on JSON", () => {
 
   let client: Client;
@@ -57,22 +74,8 @@ describe("create and drop index on JSON", () => {
     it("has the expected fields", () => {
       let fields = indexInfo[7];
       expect(fields).toHaveLength(14);
-      expect(fields).toEqual([
-        ['identifier', '$.aString', 'attribute', 'aString', 'type', 'TAG', 'SEPARATOR', '|'],
-        ['identifier', '$.anotherString', 'attribute', 'anotherString', 'type', 'TAG', 'SEPARATOR', '|'],
-        ['identifier', '$.someText', 'attribute', 'someText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
-        ['identifier', '$.someOtherText', 'attribute', 'someOtherText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
-        ['identifier', '$.aNumber', 'attribute', 'aNumber', 'type', 'NUMERIC', 'SORTABLE'],
-        ['identifier', '$.anotherNumber', 'attribute', 'anotherNumber', 'type', 'NUMERIC', 'SORTABLE'],
-        ['identifier', '$.aBoolean', 'attribute', 'aBoolean', 'type', 'TAG', 'SEPARATOR', ''],
-        ['identifier', '$.anotherBoolean', 'attribute', 'anotherBoolean', 'type', 'TAG', 'SEPARATOR', ''],
-        ['identifier', '$.aPoint', 'attribute', 'aPoint', 'type', 'GEO'],
-        ['identifier', '$.anotherPoint', 'attribute', 'anotherPoint', 'type', 'GEO'],
-        ['identifier', '$.aDate', 'attribute', 'aDate', 'type', 'NUMERIC', 'SORTABLE'],
-        ['identifier', '$.anotherDate', 'attribute', 'anotherDate', 'type', 'NUMERIC', 'SORTABLE'],
-        ['identifier', '$.someStrings[*]', 'attribute', 'someStrings', 'type', 'TAG', 'SEPARATOR', '|'],
-        ['identifier', '$.someOtherStrings[*]', 'attribute', 'someOtherStrings', 'type', 'TAG', 'SEPARATOR', '|']
-      ]);
+      console.log(fields)
+      expect(fields).toEqual(expected);
     });
 
     describe("when the index is dropped", () => {
@@ -108,22 +111,7 @@ describe("create and drop index on JSON", () => {
         expect(indexHash).toBe("p2zV8lqN3AUmui41o3PSkvLZ/XQ=");
 
         expect(fields).toHaveLength(14);
-        expect(fields).toEqual([
-          ['identifier', '$.aString', 'attribute', 'aString', 'type', 'TAG', 'SEPARATOR', '|'],
-          ['identifier', '$.anotherString', 'attribute', 'anotherString', 'type', 'TAG', 'SEPARATOR', '|'],
-          ['identifier', '$.someText', 'attribute', 'someText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
-          ['identifier', '$.someOtherText', 'attribute', 'someOtherText', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE'],
-          ['identifier', '$.aNumber', 'attribute', 'aNumber', 'type', 'NUMERIC', 'SORTABLE'],
-          ['identifier', '$.anotherNumber', 'attribute', 'anotherNumber', 'type', 'NUMERIC', 'SORTABLE'],
-          ['identifier', '$.aBoolean', 'attribute', 'aBoolean', 'type', 'TAG', 'SEPARATOR', ''],
-          ['identifier', '$.anotherBoolean', 'attribute', 'anotherBoolean', 'type', 'TAG', 'SEPARATOR', ''],
-          ['identifier', '$.aPoint', 'attribute', 'aPoint', 'type', 'GEO'],
-          ['identifier', '$.anotherPoint', 'attribute', 'anotherPoint', 'type', 'GEO'],
-          ['identifier', '$.aDate', 'attribute', 'aDate', 'type', 'NUMERIC', 'SORTABLE'],
-          ['identifier', '$.anotherDate', 'attribute', 'anotherDate', 'type', 'NUMERIC', 'SORTABLE'],
-          ['identifier', '$.someStrings[*]', 'attribute', 'someStrings', 'type', 'TAG', 'SEPARATOR', '|'],
-          ['identifier', '$.someOtherStrings[*]', 'attribute', 'someOtherStrings', 'type', 'TAG', 'SEPARATOR', '|']
-        ]);
+        expect(fields).toEqual(expected);
       });
     });
 

--- a/spec/functional/search/create-and-drop-index-on-json.spec.ts
+++ b/spec/functional/search/create-and-drop-index-on-json.spec.ts
@@ -74,7 +74,6 @@ describe("create and drop index on JSON", () => {
     it("has the expected fields", () => {
       let fields = indexInfo[7];
       expect(fields).toHaveLength(14);
-      console.log(fields)
       expect(fields).toEqual(expected);
     });
 


### PR DESCRIPTION
I noticed when I pushed the latest branch to my mirror that the build failed, and it failed locally too.

It appears to be due to this [change to RediSearch which makes sortable JSON fields UNF by default](https://github.com/RediSearch/RediSearch/pull/3182)

So, updated the tests and also made the test index spec a const as it's used in two places, and should be identical in both. The real change is the addition of the 'UNF' to the sortable JSON field specs.