### PR TITLE
Differentiate documentation version more clearly between GitHub and NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+<h2>
+<p align="center">
+⚠️ COMPATABILITY WARNING FOR DOCUMENTATION ⚠️
+</p>
+</h2>
+
+> **Warning**
+> This Documentation is not compatible with npm latest version of redis-om!
+> This page is for v0.4.x ```npm i redis-om@beta```
+
+
+> **Note**
+> By default, npm will install redis-om v0.3.x ```npm i redis-om```, and the documentation for it is found on the [npm page itself](https://www.npmjs.com/package/redis-om/v/0.3.6?activeTab=readme).
+
+
+***
+
+
 <div align="center">
   <br/>
   <br/>


### PR DESCRIPTION
Make a clearer distinction between this version of the documentation. and that which is found on the npm site.