### PR TITLE
Add clarity for definition of repository variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ const schema = new Schema('album', {
   title: { type: 'text' },
   year: { type: 'number' }
 })
+
+// redis is the connection (client) instance from createClient()
+const repository = new Repository(schema, redis)
 ```
 
 Create a JavaScript object and save it:


### PR DESCRIPTION
Add clarity for what 'repository' variable is / where it came from. Existing documentation makes a logic leap that isn't necessarily clear to a new user.