### PR TITLE
Handled issue with dots and spaces in field names, and a bit more

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Corrected parsing where empty arrays were saved to a Hash as an empty String.
+- Special characters can now, correctly, be field names
 
 
 ## 0.3.6 - 2022-07-12

--- a/lib/error/invalid-input.ts
+++ b/lib/error/invalid-input.ts
@@ -8,7 +8,7 @@ export class NullJsonInput extends InvalidInput {
   #field
 
   constructor(field: Field) {
-    const message = `Null or undefined found in field '${field.name}' of type '${field.type}' in JSON at "${field.jsonPath}".`
+    const message = `Null or undefined found in field '${field.name}' of type '${field.type}' in JSON at '${field.jsonPath}'.`
     super(message)
     this.#field = field
   }
@@ -23,7 +23,7 @@ export class InvalidJsonInput extends InvalidInput {
   #field
 
   constructor(field: Field) {
-    const message = `Unexpected value for field '${field.name}' of type '${field.type}' in JSON at "${field.jsonPath}".`
+    const message = `Unexpected value for field '${field.name}' of type '${field.type}' in JSON at '${field.jsonPath}'.`
     super(message)
     this.#field = field
   }

--- a/lib/error/invalid-value.ts
+++ b/lib/error/invalid-value.ts
@@ -8,7 +8,7 @@ export class NullJsonValue extends InvalidValue {
   #field
 
   constructor(field: Field) {
-    const message = `Null or undefined found in field '${field.name}' of type '${field.type}' from JSON path "${field.jsonPath}" in Redis.`
+    const message = `Null or undefined found in field '${field.name}' of type '${field.type}' from JSON path '${field.jsonPath}' in Redis.`
     super(message)
     this.#field = field
   }
@@ -23,7 +23,7 @@ export class InvalidJsonValue extends InvalidValue {
   #field
 
   constructor(field: Field) {
-    const message = `Unexpected value for field '${field.name}' of type '${field.type}' from JSON path "${field.jsonPath}" in Redis.`
+    const message = `Unexpected value for field '${field.name}' of type '${field.type}' from JSON path '${field.jsonPath}' in Redis.`
     super(message)
     this.#field = field
   }
@@ -38,7 +38,7 @@ export class InvalidHashValue extends InvalidValue {
   #field
 
   constructor(field: Field) {
-    const message = `Unexpected value for field '${field.name}' of type '${field.type}' from Hash field "${field.hashField}" read from Redis.`
+    const message = `Unexpected value for field '${field.name}' of type '${field.type}' from Hash field '${field.hashField}' read from Redis.`
     super(message)
     this.#field = field
   }

--- a/lib/schema/field.ts
+++ b/lib/schema/field.ts
@@ -38,7 +38,7 @@ export class Field {
   get jsonPath(): string {
     if (this.#definition.path) return this.#definition.path
     const alias = this.#definition.alias ?? this.name
-    return this.type === 'string[]' ? `$.${alias}[*]` : `$.${alias}`
+    return this.type === 'string[]' ? `$["${alias}"][*]` : `$["${alias}"]`
   }
 
   /** The separator for string[] fields when stored in Hashes. */

--- a/lib/schema/field.ts
+++ b/lib/schema/field.ts
@@ -37,7 +37,7 @@ export class Field {
   /** The JSONPath used to store this {@link Field} in a JSON document. */
   get jsonPath(): string {
     if (this.#definition.path) return this.#definition.path
-    const alias = this.#definition.alias ?? this.name
+    const alias = (this.#definition.alias ?? this.name).replace(/"/g, '\\"')
     return this.type === 'string[]' ? `$["${alias}"][*]` : `$["${alias}"]`
   }
 

--- a/lib/search/where-field.ts
+++ b/lib/search/where-field.ts
@@ -310,7 +310,13 @@ export abstract class WhereField {
   /** @internal */
   protected buildQuery(valuePortion: string): string {
     const negationPortion = this.negated ? '-' : ''
-    const fieldPortion = this.field.name
+    const fieldPortion = this.escapePunctuation(this.field.name)
     return `(${negationPortion}@${fieldPortion}:${valuePortion})`
+  }
+
+  /** @internal */
+  protected escapePunctuation(value: string): string {
+    const matchPunctuation = /[,.<>{}[\]"':;!@#$%^&()\-+=~|/\\ ]/g
+    return value.replace(matchPunctuation, '\\$&')
   }
 }

--- a/lib/search/where-string.ts
+++ b/lib/search/where-string.ts
@@ -24,8 +24,7 @@ export class WhereString extends WhereField {
   get exactly() { return this.throwMatchExcpetionReturningThis() }
 
   toString(): string {
-    const matchPunctuation = /[,.<>{}[\]"':;!@#$%^&()\-+=~|/\\ ]/g
-    const escapedValue = this.value.replace(matchPunctuation, '\\$&')
+    const escapedValue = this.escapePunctuation(this.value)
     return this.buildQuery(`{${escapedValue}}`)
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-om",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "description": "Object mapping, and more, for Redis and Node.js. Written in TypeScript.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/spec/unit/error/errors.spec.ts
+++ b/spec/unit/error/errors.spec.ts
@@ -18,16 +18,16 @@ describe("Errors", () => {
   })
 
   describe.each([
-    ["NullJsonInput", NullJsonInput, `Null or undefined found in field 'aString' of type 'string' in JSON at "$.aString".`],
-    ["InvalidJsonInput", InvalidJsonInput, `Unexpected value for field 'aString' of type 'string' in JSON at "$.aString".`],
-    ["NullJsonValue", NullJsonValue, `Null or undefined found in field 'aString' of type 'string' from JSON path "$.aString" in Redis.`],
-    ["InvalidJsonValue", InvalidJsonValue, `Unexpected value for field 'aString' of type 'string' from JSON path "$.aString" in Redis.`]
+    ["NullJsonInput", NullJsonInput, `Null or undefined found in field 'aString' of type 'string' in JSON at '$["aString"]'.`],
+    ["InvalidJsonInput", InvalidJsonInput, `Unexpected value for field 'aString' of type 'string' in JSON at '$["aString"]'.`],
+    ["NullJsonValue", NullJsonValue, `Null or undefined found in field 'aString' of type 'string' from JSON path '$["aString"]' in Redis.`],
+    ["InvalidJsonValue", InvalidJsonValue, `Unexpected value for field 'aString' of type 'string' from JSON path '$["aString"]' in Redis.`]
   ])("%s", (_, errorClass, expectedMessage) => {
     beforeEach(() => { error = new errorClass(new Field('aString', { type: 'string' })) })
     it("has the expected message", () => expect(error.message).toBe(expectedMessage))
     it("has the expected field name", () => expect(error.fieldName).toBe('aString'))
     it("has the expected field type", () => expect(error.fieldType).toBe('string'))
-    it("has the expected JSON path", () => expect(error.jsonPath).toBe('$.aString'))
+    it("has the expected JSON path", () => expect(error.jsonPath).toBe('$["aString"]'))
   })
 
   describe.each([
@@ -49,7 +49,7 @@ describe("Errors", () => {
 
   describe("InvalidHashValue", () => {
     beforeEach(() => { error = new InvalidHashValue(new Field('aString', { type: 'string' })) })
-    it("has the expected message", () => expect(error.message).toBe(`Unexpected value for field 'aString' of type 'string' from Hash field "aString" read from Redis.`))
+    it("has the expected message", () => expect(error.message).toBe(`Unexpected value for field 'aString' of type 'string' from Hash field 'aString' read from Redis.`))
     it("has the expected field name", () => expect(error.fieldName).toBe('aString'))
     it("has the expected field type", () => expect(error.fieldType).toBe('string'))
     it("has the expected Hash field", () => expect(error.hashField).toBe('aString'))

--- a/spec/unit/helpers/test-entity-and-schema.ts
+++ b/spec/unit/helpers/test-entity-and-schema.ts
@@ -80,3 +80,35 @@ export const customStopWordsSchema = new Schema("CustomStopWordsEntity", {
   useStopWords: 'CUSTOM',
   stopWords: ['foo', 'bar', 'baz']
 });
+
+export const escapedFieldsSchema = new Schema("EscapedFieldsEntity", {
+  "a,field": { type: 'string' },
+  "a.field": { type: 'string' },
+  "a<field": { type: 'string' },
+  "a>field": { type: 'string' },
+  "a{field": { type: 'string' },
+  "a}field": { type: 'string' },
+  "a[field": { type: 'string' },
+  "a]field": { type: 'string' },
+  "a\"field": { type: 'string' },
+  "a'field": { type: 'string' },
+  "a:field": { type: 'string' },
+  "a;field": { type: 'string' },
+  "a!field": { type: 'string' },
+  "a@field": { type: 'string' },
+  "a#field": { type: 'string' },
+  "a$field": { type: 'string' },
+  "a%field": { type: 'string' },
+  "a^field": { type: 'string' },
+  "a&field": { type: 'string' },
+  "a(field": { type: 'string' },
+  "a)field": { type: 'string' },
+  "a-field": { type: 'string' },
+  "a+field": { type: 'string' },
+  "a=field": { type: 'string' },
+  "a~field": { type: 'string' },
+  "a|field": { type: 'string' },
+  "a/field": { type: 'string' },
+  "a\\field": { type: 'string' },
+  "a field": { type: 'string' }
+});

--- a/spec/unit/indexer/boolean-json-fields.spec.ts
+++ b/spec/unit/indexer/boolean-json-fields.spec.ts
@@ -12,14 +12,14 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an unconfigured boolean for a JSON", {
       schemaDef: { aField: { type: 'boolean' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG' } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG' } },
       expectedWarning: null
     }],
 
     ["that defines an aliased boolean for a JSON", {
       schemaDef: { aField: { type: 'boolean', alias: 'anotherField' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.anotherField': { AS: 'aField', type: 'TAG' } },
+      expectedRedisSchema: { '$["anotherField"]': { AS: 'aField', type: 'TAG' } },
       expectedWarning: null
     }],
 
@@ -33,28 +33,28 @@ describe("#buildRediSearchSchema", () => {
     ["that defines a sorted boolean for a JSON", {
       schemaDef: { aField: { type: 'boolean', sortable: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG' } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG' } },
       expectedWarning: "You have marked a boolean field as sortable but RediSearch doesn't support the SORTABLE argument on a TAG for JSON. Ignored."
     }],
 
     ["that defines an unsorted boolean for a JSON", {
       schemaDef: { aField: { type: 'boolean', sortable: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG' } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG' } },
       expectedWarning: null
     }],
 
     ["that defines an indexed boolean for a JSON", {
       schemaDef: { aField: { type: 'boolean', indexed: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG' } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG' } },
       expectedWarning: null
     }],
 
     ["that defines an unidexed boolean for a JSON", {
       schemaDef: { aField: { type: 'boolean', indexed: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG', NOINDEX: true } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG', NOINDEX: true } },
       expectedWarning: null
     }],
 

--- a/spec/unit/indexer/date-json-fields.spec.ts
+++ b/spec/unit/indexer/date-json-fields.spec.ts
@@ -8,13 +8,13 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an unconfigured date for a JSON", {
       schemaDef: { aField: { type: 'date' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'NUMERIC' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'NUMERIC' } }
     }],
 
     ["that defines an aliased date for a JSON", {
       schemaDef: { aField: { type: 'date', alias: 'anotherField' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.anotherField': { AS: 'aField', type: 'NUMERIC' } }
+      expectedRedisSchema: { '$["anotherField"]': { AS: 'aField', type: 'NUMERIC' } }
     }],
 
     ["that defines an pathed date for a JSON", {
@@ -26,25 +26,25 @@ describe("#buildRediSearchSchema", () => {
     ["that defines a sorted date for a JSON", {
       schemaDef: { aField: { type: 'date', sortable: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'NUMERIC', SORTABLE: true } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'NUMERIC', SORTABLE: true } }
     }],
 
     ["that defines an unsorted date for a JSON", {
       schemaDef: { aField: { type: 'date', sortable: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'NUMERIC' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'NUMERIC' } }
     }],
 
     ["that defines an indexed date for a JSON", {
       schemaDef: { aField: { type: 'date', indexed: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'NUMERIC' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'NUMERIC' } }
     }],
 
     ["that defines an indexed date for a JSON", {
       schemaDef: { aField: { type: 'date', indexed: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'NUMERIC', NOINDEX: true } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'NUMERIC', NOINDEX: true } }
     }],
 
     ["that defines a fully configured date for a JSON", {

--- a/spec/unit/indexer/index-builder.spec.ts
+++ b/spec/unit/indexer/index-builder.spec.ts
@@ -72,20 +72,20 @@ describe("#buildRediSearchSchema", () => {
       } as SchemaDefinition,
       dataStructure: 'JSON',
       expectedRedisSchema: {
-        '$.aString': { type: 'TAG', AS: 'aString', SEPARATOR: '|' },
-        '$.anotherString': { type: 'TAG', AS: 'anotherString', SEPARATOR: '|' },
-        '$.someText': { type: 'TEXT', AS: 'someText' },
-        '$.someOtherText': { type: 'TEXT', AS: 'someOtherText' },
-        '$.aNumber': { type: 'NUMERIC', AS: 'aNumber' },
-        '$.anotherNumber': { type: 'NUMERIC', AS: 'anotherNumber' },
-        '$.aBoolean': { type: 'TAG', AS: 'aBoolean' },
-        '$.anotherBoolean': { type: 'TAG', AS: 'anotherBoolean' },
-        '$.aPoint': { type: 'GEO', AS: 'aPoint' },
-        '$.anotherPoint': { type: 'GEO', AS: 'anotherPoint' },
-        '$.aDate': { type: 'NUMERIC', AS: 'aDate' },
-        '$.anotherDate': { type: 'NUMERIC', AS: 'anotherDate' },
-        '$.someStrings[*]': { type: 'TAG', AS: 'someStrings', SEPARATOR: '|' },
-        '$.someOtherStrings[*]': { type: 'TAG', AS: 'someOtherStrings', SEPARATOR: '|' }
+        '$["aString"]': { type: 'TAG', AS: 'aString', SEPARATOR: '|' },
+        '$["anotherString"]': { type: 'TAG', AS: 'anotherString', SEPARATOR: '|' },
+        '$["someText"]': { type: 'TEXT', AS: 'someText' },
+        '$["someOtherText"]': { type: 'TEXT', AS: 'someOtherText' },
+        '$["aNumber"]': { type: 'NUMERIC', AS: 'aNumber' },
+        '$["anotherNumber"]': { type: 'NUMERIC', AS: 'anotherNumber' },
+        '$["aBoolean"]': { type: 'TAG', AS: 'aBoolean' },
+        '$["anotherBoolean"]': { type: 'TAG', AS: 'anotherBoolean' },
+        '$["aPoint"]': { type: 'GEO', AS: 'aPoint' },
+        '$["anotherPoint"]': { type: 'GEO', AS: 'anotherPoint' },
+        '$["aDate"]': { type: 'NUMERIC', AS: 'aDate' },
+        '$["anotherDate"]': { type: 'NUMERIC', AS: 'anotherDate' },
+        '$["someStrings"][*]': { type: 'TAG', AS: 'someStrings', SEPARATOR: '|' },
+        '$["someOtherStrings"][*]': { type: 'TAG', AS: 'someOtherStrings', SEPARATOR: '|' }
       }
     }]
 

--- a/spec/unit/indexer/numeric-json-fields.spec.ts
+++ b/spec/unit/indexer/numeric-json-fields.spec.ts
@@ -8,13 +8,13 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an unconfigured number for a JSON", {
       schemaDef: { aField: { type: 'number' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField' : { AS: 'aField', type: 'NUMERIC' } }
+      expectedRedisSchema: { '$["aField"]' : { AS: 'aField', type: 'NUMERIC' } }
     }],
 
     ["that defines an aliased number for a JSON", {
       schemaDef: { aField: { type: 'number', alias: 'anotherField' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.anotherField' : { AS: 'aField', type: 'NUMERIC' } }
+      expectedRedisSchema: { '$["anotherField"]' : { AS: 'aField', type: 'NUMERIC' } }
     }],
 
     ["that defines an pathed number for a JSON", {
@@ -26,25 +26,25 @@ describe("#buildRediSearchSchema", () => {
     ["that defines a sorted number for a JSON", {
       schemaDef: { aField: { type: 'number', sortable: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField' : { AS: 'aField', type: 'NUMERIC', SORTABLE: true } }
+      expectedRedisSchema: { '$["aField"]' : { AS: 'aField', type: 'NUMERIC', SORTABLE: true } }
     }],
 
     ["that defines an unsorted number for a JSON", {
       schemaDef: { aField: { type: 'number', sortable: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField' : { AS: 'aField', type: 'NUMERIC' } }
+      expectedRedisSchema: { '$["aField"]' : { AS: 'aField', type: 'NUMERIC' } }
     }],
 
     ["that defines an indexed number for a JSON", {
       schemaDef: { aField: { type: 'number', indexed: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField' : { AS: 'aField', type: 'NUMERIC' } }
+      expectedRedisSchema: { '$["aField"]' : { AS: 'aField', type: 'NUMERIC' } }
     }],
 
     ["that defines an unindexed number for a JSON", {
       schemaDef: { aField: { type: 'number', indexed: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField' : { AS: 'aField', type: 'NUMERIC', NOINDEX: true } }
+      expectedRedisSchema: { '$["aField"]' : { AS: 'aField', type: 'NUMERIC', NOINDEX: true } }
     }],
 
     ["that defines a fully-configured number for a JSON", {

--- a/spec/unit/indexer/point-json-fields.spec.ts
+++ b/spec/unit/indexer/point-json-fields.spec.ts
@@ -8,13 +8,13 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an unconfigured point for a JSON", {
       schemaDef: { aField: { type: 'point' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'GEO' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'GEO' } }
     }],
 
     ["that defines an aliased point for a JSON", {
       schemaDef: { aField: { type: 'point', alias: 'anotherField' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.anotherField': { AS: 'aField', type: 'GEO' } }
+      expectedRedisSchema: { '$["anotherField"]': { AS: 'aField', type: 'GEO' } }
     }],
 
     ["that defines a pathed point for a JSON", {
@@ -26,13 +26,13 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an indexed point for a JSON", {
       schemaDef: { aField: { type: 'point', indexed: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'GEO' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'GEO' } }
     }],
 
     ["that defines an unindexed point for a JSON", {
       schemaDef: { aField: { type: 'point', indexed: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'GEO', NOINDEX: true } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'GEO', NOINDEX: true } }
     }],
 
     ["that defines a fully-configured point for a JSON", {

--- a/spec/unit/indexer/string-array-json-fields.spec.ts
+++ b/spec/unit/indexer/string-array-json-fields.spec.ts
@@ -8,13 +8,13 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an unconfigured array for a JSON", {
       schemaDef: { aField: { type: 'string[]' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField[*]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } }
+      expectedRedisSchema: { '$["aField"][*]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } }
     }],
 
     ["that defines an aliased array for a JSON", {
       schemaDef: { aField: { type: 'string[]', alias: 'anotherField' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.anotherField[*]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } }
+      expectedRedisSchema: { '$["anotherField"][*]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } }
     }],
 
     ["that defines a pathed array for a JSON", {
@@ -26,13 +26,13 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an indexed array for a JSON", {
       schemaDef: { aField: { type: 'string[]', indexed: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField[*]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } }
+      expectedRedisSchema: { '$["aField"][*]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } }
     }],
 
     ["that defines an unindexed array for a JSON", {
       schemaDef: { aField: { type: 'string[]', indexed: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField[*]': { AS: 'aField', type: 'TAG', SEPARATOR: '|', NOINDEX: true } }
+      expectedRedisSchema: { '$["aField"][*]': { AS: 'aField', type: 'TAG', SEPARATOR: '|', NOINDEX: true } }
     }],
 
     ["that defines a fully-configured array for a JSON", {

--- a/spec/unit/indexer/string-json-fields.spec.ts
+++ b/spec/unit/indexer/string-json-fields.spec.ts
@@ -12,14 +12,14 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an unconfigured string for a JSON", {
       schemaDef: { aField: { type: 'string' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
       expectedWarning: null
     }],
 
     ["that defines an aliased string for a JSON", {
       schemaDef: { aField: { type: 'string', alias: 'anotherField' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.anotherField': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
+      expectedRedisSchema: { '$["anotherField"]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
       expectedWarning: null
     }],
 
@@ -33,42 +33,42 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an unsorted string for a JSON", {
       schemaDef: { aField: { type: 'string', sortable: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
       expectedWarning: null
     }],
 
     ["that defines a sorted string for a JSON", {
       schemaDef: { aField: { type: 'string', sortable: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
       expectedWarning: "You have marked a string field as sortable but RediSearch doesn't support the SORTABLE argument on a TAG for JSON. Ignored."
     }],
 
     ["that defines a separated string for a JSON", {
       schemaDef: { aField: { type: 'string', separator: ',' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG', SEPARATOR: ',' } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG', SEPARATOR: ',' } },
       expectedWarning: null
     }],
 
     ["that defines an indexed string for a JSON", {
       schemaDef: { aField: { type: 'string', indexed: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG', SEPARATOR: '|' } },
       expectedWarning: null
     }],
 
     ["that defines an unindexed string for a JSON", {
       schemaDef: { aField: { type: 'string', indexed: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG', SEPARATOR: '|', NOINDEX: true } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG', SEPARATOR: '|', NOINDEX: true } },
       expectedWarning: null
     }],
 
     ["that defines a caseSensitive string for a JSON", {
       schemaDef: { aField: { type: 'string', caseSensitive: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TAG', SEPARATOR: '|', CASESENSITIVE: true } },
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TAG', SEPARATOR: '|', CASESENSITIVE: true } },
       expectedWarning: null
     }],
 

--- a/spec/unit/indexer/text-json-fields.spec.ts
+++ b/spec/unit/indexer/text-json-fields.spec.ts
@@ -8,13 +8,13 @@ describe("#buildRediSearchSchema", () => {
     ["that defines an unconfigured text for a JSON", {
       schemaDef: { aField: { type: 'text' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT' } }
     }],
 
     ["that defines an aliased text for a JSON", {
       schemaDef: { aField: { type: 'text', alias: 'anotherField' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.anotherField': { AS: 'aField', type: 'TEXT' } }
+      expectedRedisSchema: { '$["anotherField"]': { AS: 'aField', type: 'TEXT' } }
     }],
 
     ["that defines a pathed text for a JSON", {
@@ -26,61 +26,61 @@ describe("#buildRediSearchSchema", () => {
     ["that defines a sorted text for a JSON", {
       schemaDef: { aField: { type: 'text', sortable: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT', SORTABLE: true } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT', SORTABLE: true } }
     }],
 
     ["that defines an unsorted text for a JSON", {
       schemaDef: { aField: { type: 'text', sortable: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT' } }
     }],
 
     ["that defines an indexed text for a JSON", {
       schemaDef: { aField: { type: 'text', indexed: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT' } }
     }],
 
     ["that defines an unindexed text for a JSON", {
       schemaDef: { aField: { type: 'text', indexed: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT', NOINDEX: true } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT', NOINDEX: true } }
     }],
 
     ["that defines a phonetic matcher text for a JSON", {
       schemaDef: { aField: { type: 'text', matcher: 'dm:en' } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT', PHONETIC: 'dm:en' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT', PHONETIC: 'dm:en' } }
     }],
 
     ["that defines a stemmed text for a JSON", {
       schemaDef: { aField: { type: 'text', stemming: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT' } }
     }],
 
     ["that defines an unstemmed text for a JSON", {
       schemaDef: { aField: { type: 'text', stemming: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT', NOSTEM: true } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT', NOSTEM: true } }
     }],
 
     ["that defines a normalized text for a JSON", {
       schemaDef: { aField: { type: 'text', normalized: true } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT' } }
     }],
 
     ["that defines an unnormalized text for a JSON", {
       schemaDef: { aField: { type: 'text', normalized: false } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT', SORTABLE: 'UNF' } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT', SORTABLE: 'UNF' } }
     }],
 
     ["that defines a weighted text for a JSON", {
       schemaDef: { aField: { type: 'text', weight: 2 } } as SchemaDefinition,
       dataStructure: 'JSON',
-      expectedRedisSchema: { '$.aField': { AS: 'aField', type: 'TEXT', WEIGHT: 2 } }
+      expectedRedisSchema: { '$["aField"]': { AS: 'aField', type: 'TEXT', WEIGHT: 2 } }
     }],
 
     ["that defines a fully configured text for a JSON", {

--- a/spec/unit/schema/field.spec.ts
+++ b/spec/unit/schema/field.spec.ts
@@ -58,6 +58,18 @@ describe("Field", () => {
   })
 
   describe.each([
+    ['configured with a space in the field name', 'foo bar', { expectedField: 'foo bar', expectedPath: '$["foo bar"]' }],
+    ['configured with a dot in the field name', 'foo.bar', { expectedField: 'foo.bar', expectedPath: '$["foo.bar"]' }],
+    ['configured with a quote in the field name', 'foo"bar', { expectedField: 'foo"bar', expectedPath: '$["foo\\"bar"]' }],
+  ])('%s', (_, providedFieldName, { expectedField, expectedPath } ) => {
+
+    beforeEach(() => { field = new Field(providedFieldName, { type: 'string'}) })
+
+    it("has the name as the Hash field", () => expect(field.hashField).toBe(expectedField))
+    it("has the name as a root JSON path", () => expect(field.jsonPath).toBe(expectedPath))
+  })
+
+  describe.each([
     ['sortable', true],
     ['sortable', false],
     ['caseSensitive', true],

--- a/spec/unit/schema/field.spec.ts
+++ b/spec/unit/schema/field.spec.ts
@@ -61,7 +61,7 @@ describe("Field", () => {
     ['configured with a space in the field name', 'foo bar', { expectedField: 'foo bar', expectedPath: '$["foo bar"]' }],
     ['configured with a dot in the field name', 'foo.bar', { expectedField: 'foo.bar', expectedPath: '$["foo.bar"]' }],
     ['configured with a quote in the field name', 'foo"bar', { expectedField: 'foo"bar', expectedPath: '$["foo\\"bar"]' }],
-    ['configured with a slash in the field name', 'foo\\bar', { expectedField: 'foo\\bar', expectedPath: '$["foo\\bar"]' }],
+    ['configured with a slash in the field name', 'foo\\qar', { expectedField: 'foo\\qar', expectedPath: '$["foo\\qar"]' }],
   ])('%s', (_, providedFieldName, { expectedField, expectedPath } ) => {
 
     beforeEach(() => { field = new Field(providedFieldName, { type: 'string'}) })

--- a/spec/unit/schema/field.spec.ts
+++ b/spec/unit/schema/field.spec.ts
@@ -61,6 +61,7 @@ describe("Field", () => {
     ['configured with a space in the field name', 'foo bar', { expectedField: 'foo bar', expectedPath: '$["foo bar"]' }],
     ['configured with a dot in the field name', 'foo.bar', { expectedField: 'foo.bar', expectedPath: '$["foo.bar"]' }],
     ['configured with a quote in the field name', 'foo"bar', { expectedField: 'foo"bar', expectedPath: '$["foo\\"bar"]' }],
+    ['configured with a slash in the field name', 'foo\\bar', { expectedField: 'foo\\bar', expectedPath: '$["foo\\bar"]' }],
   ])('%s', (_, providedFieldName, { expectedField, expectedPath } ) => {
 
     beforeEach(() => { field = new Field(providedFieldName, { type: 'string'}) })

--- a/spec/unit/schema/field.spec.ts
+++ b/spec/unit/schema/field.spec.ts
@@ -25,25 +25,25 @@ describe("Field", () => {
   describe.each([
 
     /* just the type */
-    ['configured as a boolean', { type: 'boolean' }, { expectedField: 'foo', expectedPath: '$.foo' }],
-    ['configured as a number', { type: 'number' }, { expectedField: 'foo', expectedPath: '$.foo' }],
-    ['configured as a date', { type: 'date' }, { expectedField: 'foo', expectedPath: '$.foo' }],
-    ['configured as a point', { type: 'point' }, { expectedField: 'foo', expectedPath: '$.foo' }],
-    ['configured as a text', { type: 'text' }, { expectedField: 'foo', expectedPath: '$.foo' }],
-    ['configured as a string', { type: 'string' }, { expectedField: 'foo', expectedPath: '$.foo' }],
-    ['configured as a string[]', { type: 'string[]' }, { expectedField: 'foo', expectedPath: '$.foo[*]' }],
+    ['configured as a boolean', { type: 'boolean' }, { expectedField: 'foo', expectedPath: '$["foo"]' }],
+    ['configured as a number', { type: 'number' }, { expectedField: 'foo', expectedPath: '$["foo"]' }],
+    ['configured as a date', { type: 'date' }, { expectedField: 'foo', expectedPath: '$["foo"]' }],
+    ['configured as a point', { type: 'point' }, { expectedField: 'foo', expectedPath: '$["foo"]' }],
+    ['configured as a text', { type: 'text' }, { expectedField: 'foo', expectedPath: '$["foo"]' }],
+    ['configured as a string', { type: 'string' }, { expectedField: 'foo', expectedPath: '$["foo"]' }],
+    ['configured as a string[]', { type: 'string[]' }, { expectedField: 'foo', expectedPath: '$["foo"][*]' }],
 
     /* aliased string */
-    ['configured as a string with an alias', { type: 'string', alias: 'bar' }, { expectedField: 'bar', expectedPath: '$.bar' }],
-    ['configured as a string with a field', { type: 'string', field: 'bar' }, { expectedField: 'bar', expectedPath: '$.foo' }],
-    ['configured as a string with a field and an alias', { type: 'string', alias: 'bar', field: 'baz' }, { expectedField: 'baz', expectedPath: '$.bar' }],
+    ['configured as a string with an alias', { type: 'string', alias: 'bar' }, { expectedField: 'bar', expectedPath: '$["bar"]' }],
+    ['configured as a string with a field', { type: 'string', field: 'bar' }, { expectedField: 'bar', expectedPath: '$["foo"]' }],
+    ['configured as a string with a field and an alias', { type: 'string', alias: 'bar', field: 'baz' }, { expectedField: 'baz', expectedPath: '$["bar"]' }],
     ['configured as a string with a path', { type: 'string', path: '$.bar.baz' }, { expectedField: 'foo', expectedPath: '$.bar.baz' }],
     ['configured as a string with a path and an alias', { type: 'string', alias: 'bar', path: '$.baz.qux' }, { expectedField: 'bar', expectedPath: '$.baz.qux' }],
 
     /* aliased string[] */
-    ['configured as a string[] with an alias', { type: 'string[]', alias: 'bar' }, { expectedField: 'bar', expectedPath: '$.bar[*]' }],
-    ['configured as a string[] with a field', { type: 'string[]', field: 'bar' }, { expectedField: 'bar', expectedPath: '$.foo[*]' }],
-    ['configured as a string[] with a field and an alias', { type: 'string[]', field: 'bar' }, { expectedField: 'bar', expectedPath: '$.foo[*]' }],
+    ['configured as a string[] with an alias', { type: 'string[]', alias: 'bar' }, { expectedField: 'bar', expectedPath: '$["bar"][*]' }],
+    ['configured as a string[] with a field', { type: 'string[]', field: 'bar' }, { expectedField: 'bar', expectedPath: '$["foo"][*]' }],
+    ['configured as a string[] with a field and an alias', { type: 'string[]', field: 'bar' }, { expectedField: 'bar', expectedPath: '$["foo"][*]' }],
     ['configured as a string[] with a path', { type: 'string[]', path: '$.bar.baz' }, { expectedField: 'foo', expectedPath: '$.bar.baz' }],
     ['configured as a string[] with a path and an alias', { type: 'string[]', alias: 'bar', path: '$.baz.qux' }, { expectedField: 'bar', expectedPath: '$.baz.qux' }]
 

--- a/spec/unit/search/search-query-with-escaped-fields.spec.ts
+++ b/spec/unit/search/search-query-with-escaped-fields.spec.ts
@@ -1,0 +1,64 @@
+import '../../helpers/custom-matchers'
+
+import { Client } from "$lib/client"
+import { Search } from "$lib/search"
+
+import { escapedFieldsSchema } from "../helpers/test-entity-and-schema"
+import { FieldNotInSchema } from "$lib/error"
+
+import { A_STRING } from '../../helpers/example-data'
+
+
+const EXPECTED_STRING_QUERY_1 = `@aString:{${A_STRING}}`
+
+describe("Search", () => {
+  describe("#query", () => {
+
+    let client: Client
+
+    beforeAll(() => {
+      client = new Client()
+    })
+
+    let search: Search
+
+    beforeEach(() => {
+      search = new Search(escapedFieldsSchema, client)
+    })
+
+    it.each([
+      [ "generates a query escaping ','", "a,field", `(@a\\,field:{${A_STRING}})` ],
+      [ "generates a query escaping '.'", "a.field", `(@a\\.field:{${A_STRING}})` ],
+      [ "generates a query escaping '<'", "a<field", `(@a\\<field:{${A_STRING}})` ],
+      [ "generates a query escaping '>'", "a>field", `(@a\\>field:{${A_STRING}})` ],
+      [ "generates a query escaping '{'", "a{field", `(@a\\{field:{${A_STRING}})` ],
+      [ "generates a query escaping '}'", "a}field", `(@a\\}field:{${A_STRING}})` ],
+      [ "generates a query escaping '['", "a[field", `(@a\\[field:{${A_STRING}})` ],
+      [ "generates a query escaping ']'", "a]field", `(@a\\]field:{${A_STRING}})` ],
+      [ "generates a query escaping '\"'", "a\"field", `(@a\\"field:{${A_STRING}})` ],
+      [ "generates a query escaping '''", "a'field", `(@a\\'field:{${A_STRING}})` ],
+      [ "generates a query escaping ':'", "a:field", `(@a\\:field:{${A_STRING}})` ],
+      [ "generates a query escaping ';'", "a;field", `(@a\\;field:{${A_STRING}})` ],
+      [ "generates a query escaping '!'", "a!field", `(@a\\!field:{${A_STRING}})` ],
+      [ "generates a query escaping '@'", "a@field", `(@a\\@field:{${A_STRING}})` ],
+      [ "generates a query escaping '#'", "a#field", `(@a\\#field:{${A_STRING}})` ],
+      [ "generates a query escaping '$'", "a$field", `(@a\\$field:{${A_STRING}})` ],
+      [ "generates a query escaping '%'", "a%field", `(@a\\%field:{${A_STRING}})` ],
+      [ "generates a query escaping '^'", "a^field", `(@a\\^field:{${A_STRING}})` ],
+      [ "generates a query escaping '&'", "a&field", `(@a\\&field:{${A_STRING}})` ],
+      [ "generates a query escaping '('", "a(field", `(@a\\(field:{${A_STRING}})` ],
+      [ "generates a query escaping ')'", "a)field", `(@a\\)field:{${A_STRING}})` ],
+      [ "generates a query escaping '-'", "a-field", `(@a\\-field:{${A_STRING}})` ],
+      [ "generates a query escaping '+'", "a+field", `(@a\\+field:{${A_STRING}})` ],
+      [ "generates a query escaping '='", "a=field", `(@a\\=field:{${A_STRING}})` ],
+      [ "generates a query escaping '~'", "a~field", `(@a\\~field:{${A_STRING}})` ],
+      [ "generates a query escaping '|'", "a|field", `(@a\\|field:{${A_STRING}})` ],
+      [ "generates a query escaping '/'", "a/field", `(@a\\/field:{${A_STRING}})` ],
+      [ "generates a query escaping '\\'", "a\\field", `(@a\\\\field:{${A_STRING}})` ],
+      [ "generates a query escaping ' '", "a field", `(@a\\ field:{${A_STRING}})` ]
+    ])('%s', (_, field, expectedQuery) => {
+      let query = search.where(field).eq(A_STRING).query
+      expect(query).toBe(expectedQuery)
+    })
+  })
+})

--- a/spec/unit/transformer/from-redis-hash.spec.ts
+++ b/spec/unit/transformer/from-redis-hash.spec.ts
@@ -112,14 +112,14 @@ describe("#fromRedisHash", () => {
     })
 
     it.each([
-      ["complains when a boolean is invalid", { aBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'aBoolean' of type 'boolean' from Hash field "aBoolean" read from Redis.`],
-      ["complains when an aliased boolean is invalid", { aRenamedBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'anotherBoolean' of type 'boolean' from Hash field "aRenamedBoolean" read from Redis.`],
-      ["complains when a number is not numeric", { aNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'aNumber' of type 'number' from Hash field "aNumber" read from Redis.`],
-      ["complains when an alaised number is not numeric", { aRenamedNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherNumber' of type 'number' from Hash field "aRenamedNumber" read from Redis.`],
-      ["complains when a date is not an epoch string", { aDate: 'NOT_A_NUMBER' }, `Unexpected value for field 'aDate' of type 'date' from Hash field "aDate" read from Redis.`],
-      ["complains when an aliased date is not an epoch string", { aRenamedDate: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherDate' of type 'date' from Hash field "aRenamedDate" read from Redis.`],
-      ["complains when a point is not a point string", { aPoint: 'NOT_A_POINT' }, `Unexpected value for field 'aPoint' of type 'point' from Hash field "aPoint" read from Redis.`],
-      ["complains when an aliased point is not a point string", { aRenamedPoint: 'NOT_A_POINT' }, `Unexpected value for field 'anotherPoint' of type 'point' from Hash field "aRenamedPoint" read from Redis.`],
+      ["complains when a boolean is invalid", { aBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'aBoolean' of type 'boolean' from Hash field 'aBoolean' read from Redis.`],
+      ["complains when an aliased boolean is invalid", { aRenamedBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'anotherBoolean' of type 'boolean' from Hash field 'aRenamedBoolean' read from Redis.`],
+      ["complains when a number is not numeric", { aNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'aNumber' of type 'number' from Hash field 'aNumber' read from Redis.`],
+      ["complains when an alaised number is not numeric", { aRenamedNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherNumber' of type 'number' from Hash field 'aRenamedNumber' read from Redis.`],
+      ["complains when a date is not an epoch string", { aDate: 'NOT_A_NUMBER' }, `Unexpected value for field 'aDate' of type 'date' from Hash field 'aDate' read from Redis.`],
+      ["complains when an aliased date is not an epoch string", { aRenamedDate: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherDate' of type 'date' from Hash field 'aRenamedDate' read from Redis.`],
+      ["complains when a point is not a point string", { aPoint: 'NOT_A_POINT' }, `Unexpected value for field 'aPoint' of type 'point' from Hash field 'aPoint' read from Redis.`],
+      ["complains when an aliased point is not a point string", { aRenamedPoint: 'NOT_A_POINT' }, `Unexpected value for field 'anotherPoint' of type 'point' from Hash field 'aRenamedPoint' read from Redis.`],
     ])('%s', (_, hashData: RedisHashData, expectedMessage) => {
       expect(() => fromRedisHash(schema, hashData)).toThrowErrorOfType(InvalidHashValue, expectedMessage)
     })

--- a/spec/unit/transformer/from-redis-json.spec.ts
+++ b/spec/unit/transformer/from-redis-json.spec.ts
@@ -157,39 +157,39 @@ describe("#fromRedisJson", () => {
     })
 
     it.each([
-      ["complains when a boolean is invalid", { aBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'aBoolean' of type 'boolean' from JSON path "$.aBoolean" in Redis.`],
-      ["complains when a pathed boolean is invalid", { aPathedBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'anotherBoolean' of type 'boolean' from JSON path "$.aPathedBoolean" in Redis.`],
-      ["complains when a nested boolean is invalid", { aNestedBoolean: { aBoolean: 'NOT_A_BOOLEAN' } }, `Unexpected value for field 'aNestedBoolean' of type 'boolean' from JSON path "$.aNestedBoolean.aBoolean" in Redis.`],
+      ["complains when a boolean is invalid", { aBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'aBoolean' of type 'boolean' from JSON path '$["aBoolean"]' in Redis.`],
+      ["complains when a pathed boolean is invalid", { aPathedBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'anotherBoolean' of type 'boolean' from JSON path '$.aPathedBoolean' in Redis.`],
+      ["complains when a nested boolean is invalid", { aNestedBoolean: { aBoolean: 'NOT_A_BOOLEAN' } }, `Unexpected value for field 'aNestedBoolean' of type 'boolean' from JSON path '$.aNestedBoolean.aBoolean' in Redis.`],
 
-      ["complains when a number is invalid", { aNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'aNumber' of type 'number' from JSON path "$.aNumber" in Redis.`],
-      ["complains when a pathed number is invalid", { aPathedNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherNumber' of type 'number' from JSON path "$.aPathedNumber" in Redis.`],
-      ["complains when a nested number is invalid", { aNestedNumber: { aNumber: 'NOT_A_NUMBER' } }, `Unexpected value for field 'aNestedNumber' of type 'number' from JSON path "$.aNestedNumber.aNumber" in Redis.`],
+      ["complains when a number is invalid", { aNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'aNumber' of type 'number' from JSON path '$["aNumber"]' in Redis.`],
+      ["complains when a pathed number is invalid", { aPathedNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherNumber' of type 'number' from JSON path '$.aPathedNumber' in Redis.`],
+      ["complains when a nested number is invalid", { aNestedNumber: { aNumber: 'NOT_A_NUMBER' } }, `Unexpected value for field 'aNestedNumber' of type 'number' from JSON path '$.aNestedNumber.aNumber' in Redis.`],
 
-      ["complains when a date is invalid", { aDate: 'NOT_A_NUMBER' }, `Unexpected value for field 'aDate' of type 'date' from JSON path "$.aDate" in Redis.`],
-      ["complains when a pathed date is invalid", { aPathedDate: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherDate' of type 'date' from JSON path "$.aPathedDate" in Redis.`],
-      ["complains when a nested date is invalid", { aNestedDate: { aDate: 'NOT_A_NUMBER' } }, `Unexpected value for field 'aNestedDate' of type 'date' from JSON path "$.aNestedDate.aDate" in Redis.`],
+      ["complains when a date is invalid", { aDate: 'NOT_A_NUMBER' }, `Unexpected value for field 'aDate' of type 'date' from JSON path '$["aDate"]' in Redis.`],
+      ["complains when a pathed date is invalid", { aPathedDate: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherDate' of type 'date' from JSON path '$.aPathedDate' in Redis.`],
+      ["complains when a nested date is invalid", { aNestedDate: { aDate: 'NOT_A_NUMBER' } }, `Unexpected value for field 'aNestedDate' of type 'date' from JSON path '$.aNestedDate.aDate' in Redis.`],
 
-      ["complains when a point is not a point string", { aPoint: 'NOT_A_POINT' }, `Unexpected value for field 'aPoint' of type 'point' from JSON path "$.aPoint" in Redis.`],
-      ["complains when a point is not a string", { aPoint: A_NUMBER }, `Unexpected value for field 'aPoint' of type 'point' from JSON path "$.aPoint" in Redis.`],
-      ["complains when a pathed point is invalid", { aPathedPoint: 'NOT_A_POINT' }, `Unexpected value for field 'anotherPoint' of type 'point' from JSON path "$.aPathedPoint" in Redis.`],
-      ["complains when a nested point is invalid", { aNestedPoint: { aPoint: 'NOT_A_POINT' } }, `Unexpected value for field 'aNestedPoint' of type 'point' from JSON path "$.aNestedPoint.aPoint" in Redis.`],
+      ["complains when a point is not a point string", { aPoint: 'NOT_A_POINT' }, `Unexpected value for field 'aPoint' of type 'point' from JSON path '$["aPoint"]' in Redis.`],
+      ["complains when a point is not a string", { aPoint: A_NUMBER }, `Unexpected value for field 'aPoint' of type 'point' from JSON path '$["aPoint"]' in Redis.`],
+      ["complains when a pathed point is invalid", { aPathedPoint: 'NOT_A_POINT' }, `Unexpected value for field 'anotherPoint' of type 'point' from JSON path '$.aPathedPoint' in Redis.`],
+      ["complains when a nested point is invalid", { aNestedPoint: { aPoint: 'NOT_A_POINT' } }, `Unexpected value for field 'aNestedPoint' of type 'point' from JSON path '$.aNestedPoint.aPoint' in Redis.`],
 
-      ["complains when a string is invalid", { aString: SOME_STRINGS }, `Unexpected value for field 'aString' of type 'string' from JSON path "$.aString" in Redis.`],
-      ["complains when a pathed string is invalid", { aPathedString: SOME_STRINGS }, `Unexpected value for field 'anotherString' of type 'string' from JSON path "$.aPathedString" in Redis.`],
-      ["complains when a nested string is invalid", { aNestedString: { aString: SOME_STRINGS } }, `Unexpected value for field 'aNestedString' of type 'string' from JSON path "$.aNestedString.aString" in Redis.`],
+      ["complains when a string is invalid", { aString: SOME_STRINGS }, `Unexpected value for field 'aString' of type 'string' from JSON path '$["aString"]' in Redis.`],
+      ["complains when a pathed string is invalid", { aPathedString: SOME_STRINGS }, `Unexpected value for field 'anotherString' of type 'string' from JSON path '$.aPathedString' in Redis.`],
+      ["complains when a nested string is invalid", { aNestedString: { aString: SOME_STRINGS } }, `Unexpected value for field 'aNestedString' of type 'string' from JSON path '$.aNestedString.aString' in Redis.`],
 
-      ["complains when text is invalid", { someText: SOME_STRINGS }, `Unexpected value for field 'someText' of type 'text' from JSON path "$.someText" in Redis.`],
-      ["complains when pathed text is invalid", { somePathedText: SOME_STRINGS }, `Unexpected value for field 'someMoreText' of type 'text' from JSON path "$.somePathedText" in Redis.`],
-      ["complains when nested text is invalid", { someNestedText: { someText: SOME_STRINGS } }, `Unexpected value for field 'someNestedText' of type 'text' from JSON path "$.someNestedText.someText" in Redis.`],
+      ["complains when text is invalid", { someText: SOME_STRINGS }, `Unexpected value for field 'someText' of type 'text' from JSON path '$["someText"]' in Redis.`],
+      ["complains when pathed text is invalid", { somePathedText: SOME_STRINGS }, `Unexpected value for field 'someMoreText' of type 'text' from JSON path '$.somePathedText' in Redis.`],
+      ["complains when nested text is invalid", { someNestedText: { someText: SOME_STRINGS } }, `Unexpected value for field 'someNestedText' of type 'text' from JSON path '$.someNestedText.someText' in Redis.`],
 
     ])('%s', (_, jsonData: RedisJsonData, expectedMessage) => {
       expect(() => fromRedisJson(schema, jsonData)).toThrowErrorOfType(InvalidJsonValue, expectedMessage)
     })
 
     it.each([
-      ["complains when a string[] contains a null", { aStringArray: [ A_STRING, null, ANOTHER_STRING ] }, `Null or undefined found in field 'aStringArray' of type 'string[]' from JSON path "$.aStringArray[*]" in Redis.`],
-      ["complains when a dispersed string[] contains null", { someOtherStrings:  [ A_STRING, null, ANOTHER_STRING] }, `Null or undefined found in field 'someStringsAsAnArray' of type 'string[]' from JSON path "$.someOtherStrings[*]" in Redis.`],
-      ["complains when a widely dispersed string[] contains null", { someObjects: [ { aString: A_STRING }, { aString: null }, { aString: ANOTHER_STRING } ] }, `Null or undefined found in field 'someOtherStringsAsAnArray' of type 'string[]' from JSON path "$.someObjects[*].aString" in Redis.`]
+      ["complains when a string[] contains a null", { aStringArray: [ A_STRING, null, ANOTHER_STRING ] }, `Null or undefined found in field 'aStringArray' of type 'string[]' from JSON path '$["aStringArray"][*]' in Redis.`],
+      ["complains when a dispersed string[] contains null", { someOtherStrings:  [ A_STRING, null, ANOTHER_STRING] }, `Null or undefined found in field 'someStringsAsAnArray' of type 'string[]' from JSON path '$.someOtherStrings[*]' in Redis.`],
+      ["complains when a widely dispersed string[] contains null", { someObjects: [ { aString: A_STRING }, { aString: null }, { aString: ANOTHER_STRING } ] }, `Null or undefined found in field 'someOtherStringsAsAnArray' of type 'string[]' from JSON path '$.someObjects[*].aString' in Redis.`]
 
     ])('%s', (_, jsonData: RedisJsonData, expectedMessage) => {
       expect(() => fromRedisJson(schema, jsonData)).toThrowErrorOfType(NullJsonValue, expectedMessage)

--- a/spec/unit/transformer/to-redis-json.spec.ts
+++ b/spec/unit/transformer/to-redis-json.spec.ts
@@ -200,46 +200,46 @@ describe("#toRedisJson", () => {
     it.each([
 
       // boolean
-      ["complains when a boolean is not a boolean", { aBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'aBoolean' of type 'boolean' in JSON at "$.aBoolean".`],
-      ["complains when a pathed boolean is not a boolean", { aPathedBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'anotherBoolean' of type 'boolean' in JSON at "$.aPathedBoolean".`],
-      ["complains when a nested boolean is not a boolean", { aNestedBoolean: { aBoolean: 'NOT_A_BOOLEAN' } }, `Unexpected value for field 'aNestedBoolean' of type 'boolean' in JSON at "$.aNestedBoolean.aBoolean".`],
-      ["complains when a pathed boolean points to multiple results", { someBooleans: [ true, false, true ] }, `Unexpected value for field 'someBooleans' of type 'boolean' in JSON at "$.someBooleans[*]".`],
+      ["complains when a boolean is not a boolean", { aBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'aBoolean' of type 'boolean' in JSON at '$["aBoolean"]'.`],
+      ["complains when a pathed boolean is not a boolean", { aPathedBoolean: 'NOT_A_BOOLEAN' }, `Unexpected value for field 'anotherBoolean' of type 'boolean' in JSON at '$.aPathedBoolean'.`],
+      ["complains when a nested boolean is not a boolean", { aNestedBoolean: { aBoolean: 'NOT_A_BOOLEAN' } }, `Unexpected value for field 'aNestedBoolean' of type 'boolean' in JSON at '$.aNestedBoolean.aBoolean'.`],
+      ["complains when a pathed boolean points to multiple results", { someBooleans: [ true, false, true ] }, `Unexpected value for field 'someBooleans' of type 'boolean' in JSON at '$.someBooleans[*]'.`],
 
       // number
-      ["complains when a number is not a number", { aNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'aNumber' of type 'number' in JSON at "$.aNumber".`],
-      ["complains when a pathed number is not a number", { aPathedNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherNumber' of type 'number' in JSON at "$.aPathedNumber".`],
-      ["complains when a nested number is not a number", { aNestedNumber: { aNumber: 'NOT_A_NUMBER' } }, `Unexpected value for field 'aNestedNumber' of type 'number' in JSON at "$.aNestedNumber.aNumber".`],
-      ["complains when a pathed number points to multiple results", { someNumbers: [ 42, 23, 13 ] }, `Unexpected value for field 'someNumbers' of type 'number' in JSON at "$.someNumbers[*]".`],
+      ["complains when a number is not a number", { aNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'aNumber' of type 'number' in JSON at '$["aNumber"]'.`],
+      ["complains when a pathed number is not a number", { aPathedNumber: 'NOT_A_NUMBER' }, `Unexpected value for field 'anotherNumber' of type 'number' in JSON at '$.aPathedNumber'.`],
+      ["complains when a nested number is not a number", { aNestedNumber: { aNumber: 'NOT_A_NUMBER' } }, `Unexpected value for field 'aNestedNumber' of type 'number' in JSON at '$.aNestedNumber.aNumber'.`],
+      ["complains when a pathed number points to multiple results", { someNumbers: [ 42, 23, 13 ] }, `Unexpected value for field 'someNumbers' of type 'number' in JSON at '$.someNumbers[*]'.`],
 
       // date
-      ["complains when a date is not a date", { aDate: true }, `Unexpected value for field 'aDate' of type 'date' in JSON at "$.aDate".`],
-      ["complains when a date is not a date string", { aDate: 'NOT_A_DATE' }, `Unexpected value for field 'aDate' of type 'date' in JSON at "$.aDate".`],
-      ["complains when a pathed date is not a date", { aPathedDate: true }, `Unexpected value for field 'anotherDate' of type 'date' in JSON at "$.aPathedDate".`],
-      ["complains when a pathed date is not a date string", { aPathedDate: 'NOT_A_DATE' }, `Unexpected value for field 'anotherDate' of type 'date' in JSON at "$.aPathedDate".`],
-      ["complains when a nested date is not a date", { aNestedDate: { aDate: true } }, `Unexpected value for field 'aNestedDate' of type 'date' in JSON at "$.aNestedDate.aDate".`],
-      ["complains when a nested date is not a date string", { aNestedDate: { aDate: 'NOT_A_DATE' } }, `Unexpected value for field 'aNestedDate' of type 'date' in JSON at "$.aNestedDate.aDate".`],
-      ["complains when a pathed date points to multiple results", { someDates: [ A_DATE, A_DATE, A_DATE ] }, `Unexpected value for field 'someDates' of type 'date' in JSON at "$.someDates[*]".`],
+      ["complains when a date is not a date", { aDate: true }, `Unexpected value for field 'aDate' of type 'date' in JSON at '$["aDate"]'.`],
+      ["complains when a date is not a date string", { aDate: 'NOT_A_DATE' }, `Unexpected value for field 'aDate' of type 'date' in JSON at '$["aDate"]'.`],
+      ["complains when a pathed date is not a date", { aPathedDate: true }, `Unexpected value for field 'anotherDate' of type 'date' in JSON at '$.aPathedDate'.`],
+      ["complains when a pathed date is not a date string", { aPathedDate: 'NOT_A_DATE' }, `Unexpected value for field 'anotherDate' of type 'date' in JSON at '$.aPathedDate'.`],
+      ["complains when a nested date is not a date", { aNestedDate: { aDate: true } }, `Unexpected value for field 'aNestedDate' of type 'date' in JSON at '$.aNestedDate.aDate'.`],
+      ["complains when a nested date is not a date string", { aNestedDate: { aDate: 'NOT_A_DATE' } }, `Unexpected value for field 'aNestedDate' of type 'date' in JSON at '$.aNestedDate.aDate'.`],
+      ["complains when a pathed date points to multiple results", { someDates: [ A_DATE, A_DATE, A_DATE ] }, `Unexpected value for field 'someDates' of type 'date' in JSON at '$.someDates[*]'.`],
 
       // point
-      ["complains when a point is not a point", { aPoint: 'NOT_A_POINT' }, `Unexpected value for field 'aPoint' of type 'point' in JSON at "$.aPoint".`],
-      ["complains when a point is a partial point", { aPoint: A_PARITAL_POINT }, `Unexpected value for field 'aPoint' of type 'point' in JSON at "$.aPoint".`],
-      ["complains when a pathed point is not a point", { aPathedPoint: 'NOT_A_POINT' }, `Unexpected value for field 'anotherPoint' of type 'point' in JSON at "$.aPathedPoint".`],
-      ["complains when a pathed point is a partial point", { aPathedPoint: A_PARITAL_POINT }, `Unexpected value for field 'anotherPoint' of type 'point' in JSON at "$.aPathedPoint".`],
-      ["complains when a nested point is not a point", { aNestedPoint: { aPoint: 'NOT_A_POINT' } }, `Unexpected value for field 'aNestedPoint' of type 'point' in JSON at "$.aNestedPoint.aPoint".`],
-      ["complains when a nested point is a partial point", { aNestedPoint: { aPoint: A_PARITAL_POINT } }, `Unexpected value for field 'aNestedPoint' of type 'point' in JSON at "$.aNestedPoint.aPoint".`],
-      ["complains when a pathed point points to multiple results", { somePoints: [ A_POINT, A_POINT, A_POINT ] }, `Unexpected value for field 'somePoints' of type 'point' in JSON at "$.somePoints[*]".`],
+      ["complains when a point is not a point", { aPoint: 'NOT_A_POINT' }, `Unexpected value for field 'aPoint' of type 'point' in JSON at '$["aPoint"]'.`],
+      ["complains when a point is a partial point", { aPoint: A_PARITAL_POINT }, `Unexpected value for field 'aPoint' of type 'point' in JSON at '$["aPoint"]'.`],
+      ["complains when a pathed point is not a point", { aPathedPoint: 'NOT_A_POINT' }, `Unexpected value for field 'anotherPoint' of type 'point' in JSON at '$.aPathedPoint'.`],
+      ["complains when a pathed point is a partial point", { aPathedPoint: A_PARITAL_POINT }, `Unexpected value for field 'anotherPoint' of type 'point' in JSON at '$.aPathedPoint'.`],
+      ["complains when a nested point is not a point", { aNestedPoint: { aPoint: 'NOT_A_POINT' } }, `Unexpected value for field 'aNestedPoint' of type 'point' in JSON at '$.aNestedPoint.aPoint'.`],
+      ["complains when a nested point is a partial point", { aNestedPoint: { aPoint: A_PARITAL_POINT } }, `Unexpected value for field 'aNestedPoint' of type 'point' in JSON at '$.aNestedPoint.aPoint'.`],
+      ["complains when a pathed point points to multiple results", { somePoints: [ A_POINT, A_POINT, A_POINT ] }, `Unexpected value for field 'somePoints' of type 'point' in JSON at '$.somePoints[*]'.`],
 
       // string
-      ["complains when a string is not a string", { aString: A_DATE }, `Unexpected value for field 'aString' of type 'string' in JSON at "$.aString".`],
-      ["complains when a pathed string is not a string", { aPathedString: A_DATE }, `Unexpected value for field 'anotherString' of type 'string' in JSON at "$.aPathedString".`],
-      ["complains when a nested string is not a string", { aNestedString: { aString: A_DATE } }, `Unexpected value for field 'aNestedString' of type 'string' in JSON at "$.aNestedString.aString".`],
-      ["complains when a pathed string points to multiple results", { someStrings: SOME_STRINGS }, `Unexpected value for field 'someStrings' of type 'string' in JSON at "$.someStrings[*]".`],
+      ["complains when a string is not a string", { aString: A_DATE }, `Unexpected value for field 'aString' of type 'string' in JSON at '$["aString"]'.`],
+      ["complains when a pathed string is not a string", { aPathedString: A_DATE }, `Unexpected value for field 'anotherString' of type 'string' in JSON at '$.aPathedString'.`],
+      ["complains when a nested string is not a string", { aNestedString: { aString: A_DATE } }, `Unexpected value for field 'aNestedString' of type 'string' in JSON at '$.aNestedString.aString'.`],
+      ["complains when a pathed string points to multiple results", { someStrings: SOME_STRINGS }, `Unexpected value for field 'someStrings' of type 'string' in JSON at '$.someStrings[*]'.`],
 
       // text
-      ["complains when text is not a string", { someText: A_DATE }, `Unexpected value for field 'someText' of type 'text' in JSON at "$.someText".`],
-      ["complains when pathed text is not a string", { somePathedText: A_DATE }, `Unexpected value for field 'someMoreText' of type 'text' in JSON at "$.somePathedText".`],
-      ["complains when nested text is not a string", { someNestedText: { someText: A_DATE } }, `Unexpected value for field 'someNestedText' of type 'text' in JSON at "$.someNestedText.someText".`],
-      ["complains when a pathed text points to multiple results", { arrayOfText: SOME_STRINGS }, `Unexpected value for field 'arrayOfText' of type 'text' in JSON at "$.arrayOfText[*]".`],
+      ["complains when text is not a string", { someText: A_DATE }, `Unexpected value for field 'someText' of type 'text' in JSON at '$["someText"]'.`],
+      ["complains when pathed text is not a string", { somePathedText: A_DATE }, `Unexpected value for field 'someMoreText' of type 'text' in JSON at '$.somePathedText'.`],
+      ["complains when nested text is not a string", { someNestedText: { someText: A_DATE } }, `Unexpected value for field 'someNestedText' of type 'text' in JSON at '$.someNestedText.someText'.`],
+      ["complains when a pathed text points to multiple results", { arrayOfText: SOME_STRINGS }, `Unexpected value for field 'arrayOfText' of type 'text' in JSON at '$.arrayOfText[*]'.`],
 
     ])('%s', (_, data, expectedMessage) => {
       expect(() => toRedisJson(schema, data)).toThrowErrorOfType(InvalidJsonInput, expectedMessage)
@@ -248,11 +248,11 @@ describe("#toRedisJson", () => {
     it.each([
 
       // string[]
-      ["complains when a string[] contains null", { aStringArray: [ A_STRING, null, ANOTHER_STRING ] }, `Null or undefined found in field 'aStringArray' of type 'string[]' in JSON at "$.aStringArray[*]".`],
-      ["complains when a string[] contains undefined", { aStringArray: [ A_STRING, undefined, ANOTHER_STRING] }, `Null or undefined found in field 'aStringArray' of type 'string[]' in JSON at "$.aStringArray[*]".`],
-      ["complains when a dispersed string[] contains null", { someOtherStrings:  [ A_STRING, null, ANOTHER_STRING] }, `Null or undefined found in field 'someStringsAsAnArray' of type 'string[]' in JSON at "$.someOtherStrings[*]".`],
-      ["complains when a dispersed string[] contains undefined", { someOtherStrings:  [ A_STRING, undefined, ANOTHER_STRING] }, `Null or undefined found in field 'someStringsAsAnArray' of type 'string[]' in JSON at "$.someOtherStrings[*]".`],
-      ["complains when a widely dispersed string[] contains null", { someObjects: [ { aString: A_STRING }, { aString: null }, { aString: ANOTHER_STRING } ] }, `Null or undefined found in field 'someOtherStringsAsAnArray' of type 'string[]' in JSON at "$.someObjects[*].aString".`]
+      ["complains when a string[] contains null", { aStringArray: [ A_STRING, null, ANOTHER_STRING ] }, `Null or undefined found in field 'aStringArray' of type 'string[]' in JSON at '$["aStringArray"][*]'.`],
+      ["complains when a string[] contains undefined", { aStringArray: [ A_STRING, undefined, ANOTHER_STRING] }, `Null or undefined found in field 'aStringArray' of type 'string[]' in JSON at '$["aStringArray"][*]'.`],
+      ["complains when a dispersed string[] contains null", { someOtherStrings:  [ A_STRING, null, ANOTHER_STRING] }, `Null or undefined found in field 'someStringsAsAnArray' of type 'string[]' in JSON at '$.someOtherStrings[*]'.`],
+      ["complains when a dispersed string[] contains undefined", { someOtherStrings:  [ A_STRING, undefined, ANOTHER_STRING] }, `Null or undefined found in field 'someStringsAsAnArray' of type 'string[]' in JSON at '$.someOtherStrings[*]'.`],
+      ["complains when a widely dispersed string[] contains null", { someObjects: [ { aString: A_STRING }, { aString: null }, { aString: ANOTHER_STRING } ] }, `Null or undefined found in field 'someOtherStringsAsAnArray' of type 'string[]' in JSON at '$.someObjects[*].aString'.`]
 
     ])('%s', (_, data, expectedMessage) => {
       expect(() => toRedisJson(schema, data)).toThrowErrorOfType(NullJsonInput, expectedMessage)


### PR DESCRIPTION
Special characters are now all usable in search queries. Field names for JSON can have spaces and dots.

Resolves #130.