### PR TITLE
Generic Types for stricter type safety, and search

### DIFF
--- a/lib/client/client.ts
+++ b/lib/client/client.ts
@@ -1,7 +1,7 @@
 import { createClient, createCluster, RediSearchSchema, SearchOptions } from 'redis'
 
 import { Repository } from '../repository'
-import { Schema } from '../schema'
+import {InferSchema, Schema} from '../schema'
 import { RedisOmError } from '../error'
 
 /** A conventional Redis connection. */
@@ -116,7 +116,7 @@ export class Client {
    * @param schema The schema.
    * @returns A repository for the provided schema.
    */
-  fetchRepository(schema: Schema): Repository {
+  fetchRepository<T extends Schema<any>>(schema: T): Repository<InferSchema<T>> {
     this.#validateRedisOpen()
     return new Repository(schema, this)
   }

--- a/lib/entity/entity.ts
+++ b/lib/entity/entity.ts
@@ -14,7 +14,7 @@ export type EntityInternal = {
 
 /** Defines the objects returned from calls to {@link Repository | repositories }. */
 export type Entity = EntityData & EntityInternal
-export type EntityKeys<T extends Entity> = Exclude<keyof T, symbol | number>
+export type EntityKeys<T extends Entity> = Exclude<keyof T, keyof EntityInternal>;
 
 /** The free-form data associated with an {@link Entity}. */
 export type EntityData = {
@@ -22,7 +22,7 @@ export type EntityData = {
 }
 
 /** Valid types for values in an {@link Entity}. */
-export type EntityDataValue = string | number | boolean | Date | Point | null | undefined | Array<EntityDataValue | EntityData>
+export type EntityDataValue = string | number | boolean | Date | Point | null | undefined | Array<EntityDataValue | EntityData>
 
 /** Defines a point on the globe using longitude and latitude. */
 export type Point = {

--- a/lib/entity/entity.ts
+++ b/lib/entity/entity.ts
@@ -4,15 +4,17 @@ export const EntityId = Symbol('entityId')
 /** The Symbol used to access the keyname of an {@link Entity}. */
 export const EntityKeyName = Symbol('entityKeyName')
 
-/** Defines the objects returned from calls to {@link Repository | repositories }. */
-export type Entity = EntityData & {
-
+export type EntityInternal = {
   /** The unique ID of the {@link Entity}. Access using the {@link EntityId} Symbol. */
   [EntityId]?: string
 
   /** The key the {@link Entity} is stored under inside of Redis. Access using the {@link EntityKeyName} Symbol. */
   [EntityKeyName]?: string
 }
+
+/** Defines the objects returned from calls to {@link Repository | repositories }. */
+export type Entity = EntityData & EntityInternal
+export type EntityKeys<T extends Entity> = Exclude<keyof T, symbol | number>
 
 /** The free-form data associated with an {@link Entity}. */
 export type EntityData = {

--- a/lib/repository/repository.ts
+++ b/lib/repository/repository.ts
@@ -142,7 +142,7 @@ export class Repository<T extends Entity = Record<string, any>> {
    */
   async save(id: string, entity: T): Promise<T>
 
-  async save(entityOrId: T | string, maybeEntity?: T): Promise<Entity> {
+  async save(entityOrId: T | string, maybeEntity?: T): Promise<T> {
     let entity: T | undefined
     let entityId: string | undefined
 

--- a/lib/schema/definitions.ts
+++ b/lib/schema/definitions.ts
@@ -1,3 +1,5 @@
+import {Entity, EntityKeys} from "$lib/entity";
+
 /** Valid field types for a {@link FieldDefinition}. */
 export type FieldType = 'boolean' | 'date' | 'number' | 'number[]' | 'point' | 'string' | 'string[]' | 'text'
 
@@ -120,4 +122,4 @@ export type FieldDefinition =
   TextFieldDefinition
 
 /** Group of {@link FieldDefinition}s that define the schema for an {@link Entity}. */
-export type SchemaDefinition = Record<string, FieldDefinition>
+export type SchemaDefinition<T extends Entity = Record<string, any>> = Record<EntityKeys<T>, FieldDefinition>

--- a/lib/schema/field.ts
+++ b/lib/schema/field.ts
@@ -5,7 +5,7 @@ import { AllFieldDefinition, FieldDefinition, FieldType } from './definitions'
  */
 export class Field {
 
-  #name: string
+  readonly #name: string
   #definition: AllFieldDefinition
 
   /**

--- a/lib/schema/schema.ts
+++ b/lib/schema/schema.ts
@@ -120,7 +120,7 @@ export class Schema<T extends Entity = Record<string, any>> {
    */
   async generateId(): Promise<string> {
     const ulidStrategy = () => ulid()
-    return (this.#options?.idStrategy ?? ulidStrategy)();
+    return await (this.#options?.idStrategy ?? ulidStrategy)();
   }
 
   /**

--- a/lib/schema/schema.ts
+++ b/lib/schema/schema.ts
@@ -1,13 +1,13 @@
-import { createHash } from 'crypto'
-import { ulid } from 'ulid'
+import {createHash} from 'crypto'
+import {ulid} from 'ulid'
 
-import { Entity, EntityKeys } from "../entity"
+import {Entity, EntityKeys} from "../entity"
 
-import { IdStrategy, DataStructure, StopWordOptions, SchemaOptions } from './options'
+import {DataStructure, IdStrategy, SchemaOptions, StopWordOptions} from './options'
 
-import { FieldDefinition, SchemaDefinition } from './definitions'
-import { Field } from './field'
-import { InvalidSchema } from '../error'
+import {FieldDefinition, SchemaDefinition} from './definitions'
+import {Field} from './field'
+import {InvalidSchema} from '../error'
 
 
 /**
@@ -85,7 +85,7 @@ export class Schema<T extends Entity = Record<string, any>> {
    * @param name The name of the {@link Field} in this Schema.
    * @returns The {@link Field}, or null of not found.
    */
-  fieldByName(name: string): Field | null {
+  fieldByName(name: EntityKeys<T>): Field | null {
     return this.#fieldsByName[name] ?? null
   }
 
@@ -145,7 +145,7 @@ export class Schema<T extends Entity = Record<string, any>> {
   #createFields() {
     const entries = Object.entries(this.#definition) as [EntityKeys<T>, FieldDefinition][];
     return entries.forEach(([fieldName, fieldDef]) => {
-      const field = new Field(fieldName, fieldDef)
+      const field = new Field(String(fieldName), fieldDef)
       this.#validateField(field)
       this.#fieldsByName[fieldName] = field
     })

--- a/lib/schema/schema.ts
+++ b/lib/schema/schema.ts
@@ -1,11 +1,11 @@
 import { createHash } from 'crypto'
 import { ulid } from 'ulid'
 
-import { Entity } from "../entity"
+import { Entity, EntityKeys } from "../entity"
 
 import { IdStrategy, DataStructure, StopWordOptions, SchemaOptions } from './options'
 
-import { SchemaDefinition } from './definitions'
+import { FieldDefinition, SchemaDefinition } from './definitions'
 import { Field } from './field'
 import { InvalidSchema } from '../error'
 
@@ -16,7 +16,17 @@ import { InvalidSchema } from '../error'
  * a {@link SchemaDefinition}, and optionally {@link SchemaOptions}:
  *
  * ```typescript
- * const schema = new Schema('foo', {
+ * interface Foo extends Entity {
+ *   aString: string,
+ *   aNumber: number,
+ *   aBoolean: boolean,
+ *   someText: string,
+ *   aPoint: Point,
+ *   aDate: Date,
+ *   someStrings: string[],
+ * }
+ *
+ * const schema = new Schema<Foo>('foo', {
  *   aString: { type: 'string' },
  *   aNumber: { type: 'number' },
  *   aBoolean: { type: 'boolean' },
@@ -32,11 +42,11 @@ import { InvalidSchema } from '../error'
  * A Schema is primarily used by a {@link Repository} which requires a Schema in
  * its constructor.
  */
-export class Schema {
+export class Schema<T extends Entity = Record<string, any>> {
 
-  #schemaName: string
-  #fieldsByName: Record<string, Field> = {}
-  #definition: SchemaDefinition
+  readonly #schemaName: string
+  #fieldsByName = {} as Record<EntityKeys<T>, Field>;
+  readonly #definition: SchemaDefinition<T>
   #options?: SchemaOptions
 
   /**
@@ -46,7 +56,7 @@ export class Schema {
    * @param schemaDef Defines all of the fields for the Schema and how they are mapped to Redis.
    * @param options Additional options for this Schema.
    */
-  constructor(schemaName: string, schemaDef: SchemaDefinition, options?: SchemaOptions) {
+  constructor(schemaName: string, schemaDef: SchemaDefinition<T>, options?: SchemaOptions) {
     this.#schemaName = schemaName
     this.#definition = schemaDef
     this.#options = options
@@ -110,7 +120,7 @@ export class Schema {
    */
   async generateId(): Promise<string> {
     const ulidStrategy = () => ulid()
-    return await (this.#options?.idStrategy ?? ulidStrategy)()
+    return (this.#options?.idStrategy ?? ulidStrategy)();
   }
 
   /**
@@ -133,7 +143,8 @@ export class Schema {
   }
 
   #createFields() {
-    return Object.entries(this.#definition).forEach(([fieldName, fieldDef]) => {
+    const entries = Object.entries(this.#definition) as [EntityKeys<T>, FieldDefinition][];
+    return entries.forEach(([fieldName, fieldDef]) => {
       const field = new Field(fieldName, fieldDef)
       this.#validateField(field)
       this.#fieldsByName[fieldName] = field
@@ -166,3 +177,5 @@ export class Schema {
       throw new InvalidSchema(`The field '${field.name}' is configured with a type of '${field.type}'. This type is only valid with a data structure of 'JSON'.`)
   }
 }
+
+export type InferSchema<T> = T extends Schema<infer R> ? R : never;

--- a/lib/search/results-converter.ts
+++ b/lib/search/results-converter.ts
@@ -1,7 +1,7 @@
-import { RedisHashData, RedisJsonData, SearchDocument, SearchResults } from "../client"
-import { Entity, EntityData, EntityId, EntityKeyName } from "../entity"
-import { Schema } from "../schema"
-import { fromRedisHash, fromRedisJson } from "../transformer"
+import {RedisHashData, RedisJsonData, SearchDocument, SearchResults} from "../client"
+import {Entity, EntityData, EntityId, EntityKeyName} from "../entity"
+import {Schema} from "../schema"
+import {fromRedisHash, fromRedisJson} from "../transformer"
 
 export function extractCountFromSearchResults(results: SearchResults): number {
   return results.total
@@ -11,13 +11,12 @@ export function extractKeyNamesFromSearchResults(results: SearchResults): string
   return results.documents.map(document => document.id)
 }
 
-export function extractEntityIdsFromSearchResults(schema: Schema, results: SearchResults): string[] {
+export function extractEntityIdsFromSearchResults<T extends Entity>(schema: Schema<T>, results: SearchResults): string[] {
   const keyNames = extractKeyNamesFromSearchResults(results)
-  const entityIds = keyNamesToEntityIds(schema.schemaName, keyNames)
-  return entityIds
+  return keyNamesToEntityIds(schema.schemaName, keyNames)
 }
 
-export function extractEntitiesFromSearchResults(schema: Schema, results: SearchResults): Entity[] {
+export function extractEntitiesFromSearchResults<T extends Entity>(schema: Schema<T>, results: SearchResults): T[] {
   if (schema.dataStructure === 'HASH') {
     return results.documents.map(document => hashDocumentToEntity(schema, document))
   } else {
@@ -25,28 +24,25 @@ export function extractEntitiesFromSearchResults(schema: Schema, results: Search
   }
 }
 
-function hashDocumentToEntity(schema: Schema, document: SearchDocument): Entity {
+function hashDocumentToEntity<T extends Entity>(schema: Schema<T>, document: SearchDocument): T {
   const keyName: string = document.id
   const hashData: RedisHashData = document.value
 
   const entityData = fromRedisHash(schema, hashData)
-  const entity = enrichEntityData(schema.schemaName, keyName, entityData)
-  return entity
+  return enrichEntityData(schema.schemaName, keyName, entityData)
 }
 
-function jsonDocumentToEntity(schema: Schema, document: SearchDocument): Entity {
+function jsonDocumentToEntity<T extends Entity>(schema: Schema<T>, document: SearchDocument): T {
   const keyName: string = document.id
   const jsonData: RedisJsonData = document.value['$'] ?? false ? JSON.parse(document.value['$']) : document.value
 
   const entityData = fromRedisJson(schema, jsonData)
-  const entity = enrichEntityData(schema.schemaName, keyName, entityData)
-  return entity
+  return enrichEntityData(schema.schemaName, keyName, entityData)
 }
 
-function enrichEntityData(keyPrefix: string, keyName: string, entityData: EntityData) {
+function enrichEntityData<T extends Entity>(keyPrefix: string, keyName: string, entityData: EntityData): T {
   const entityId = keyNameToEntityId(keyPrefix, keyName)
-  const entity = { ...entityData, [EntityId]: entityId, [EntityKeyName]: keyName}
-  return entity
+  return {...entityData, [EntityId]: entityId, [EntityKeyName]: keyName} as T
 }
 
 function keyNamesToEntityIds(keyPrefix: string, keyNames: string[]): string[] {
@@ -56,6 +52,5 @@ function keyNamesToEntityIds(keyPrefix: string, keyNames: string[]): string[] {
 function keyNameToEntityId(keyPrefix: string, keyName: string): string {
   const escapedPrefix = keyPrefix.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&')
   const regex = new RegExp(`^${escapedPrefix}:`)
-  const entityId = keyName.replace(regex, "")
-  return entityId
+  return keyName.replace(regex, "")
 }

--- a/lib/search/search.ts
+++ b/lib/search/search.ts
@@ -1,39 +1,41 @@
-import {SearchOptions} from "redis"
+import { SearchOptions } from "redis";
 
-import {Client, SearchResults} from "../client"
-import {Entity, EntityKeys} from '../entity'
-import {Schema} from "../schema"
+import { Client, SearchResults } from "../client";
+import { Entity, EntityKeys } from "../entity";
+import { Schema } from "../schema";
 
-import {Where} from './where'
-import {WhereAnd} from './where-and'
-import {WhereOr} from './where-or'
-import {WhereField} from './where-field'
-import {WhereStringArray} from './where-string-array'
-import {WhereHashBoolean, WhereJsonBoolean} from './where-boolean'
-import {WhereNumber} from './where-number'
-import {WherePoint} from './where-point'
-import {WhereString} from './where-string'
-import {WhereText} from './where-text'
+import { Where } from "./where";
+import { WhereAnd } from "./where-and";
+import { WhereOr } from "./where-or";
+import { WhereField } from "./where-field";
+import { WhereStringArray } from "./where-string-array";
+import { WhereHashBoolean, WhereJsonBoolean } from "./where-boolean";
+import { WhereNumber } from "./where-number";
+import { WherePoint } from "./where-point";
+import { WhereString } from "./where-string";
+import { WhereText } from "./where-text";
 
 import {
   extractCountFromSearchResults,
   extractEntitiesFromSearchResults,
   extractEntityIdsFromSearchResults,
-  extractKeyNamesFromSearchResults
-} from "./results-converter"
-import {FieldNotInSchema, RedisOmError, SearchError} from "../error"
-import {WhereDate} from "./where-date"
+  extractKeyNamesFromSearchResults,
+} from "./results-converter";
+import { FieldNotInSchema, RedisOmError, SearchError } from "../error";
+import { WhereDate } from "./where-date";
 
 /**
  * A function that takes a {@link Search} and returns a {@link Search}. Used in nested queries.
  * @template TEntity The type of {@link Entity} being sought.
  */
-export type SubSearchFunction<T extends Entity> = (search: Search<T>) => Search<T>
+export type SubSearchFunction<T extends Entity> = (
+  search: Search<T>,
+) => Search<T>;
 
-type AndOrConstructor = new (left: Where, right: Where) => Where
+type AndOrConstructor = new (left: Where, right: Where) => Where;
 
 // This is a simplified redefintion of the SortByProperty type that is not exported by Node Redis
-type SortOptions = { BY: string, DIRECTION: 'ASC' | 'DESC' }
+type SortOptions = { BY: string; DIRECTION: "ASC" | "DESC" };
 
 /**
  * Abstract base class for {@link Search} and {@link RawSearch} that
@@ -41,24 +43,23 @@ type SortOptions = { BY: string, DIRECTION: 'ASC' | 'DESC' }
  * @template TEntity The type of {@link Entity} being sought.
  */
 export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
+  /** @internal */
+  protected schema: Schema<T>;
 
   /** @internal */
-  protected schema: Schema<T>
+  protected client: Client;
 
   /** @internal */
-  protected client: Client
-
-  /** @internal */
-  protected sortOptions?: SortOptions
+  protected sortOptions?: SortOptions;
 
   /** @internal */
   constructor(schema: Schema<T>, client: Client) {
-    this.schema = schema
-    this.client = client
+    this.schema = schema;
+    this.client = client;
   }
 
   /** @internal */
-  abstract get query(): string
+  abstract get query(): string;
 
   /**
    * Applies an ascending sort to the query.
@@ -66,14 +67,14 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns this
    */
   sortAscending(field: EntityKeys<T>): AbstractSearch<T> {
-    return this.sortBy(field, 'ASC')
+    return this.sortBy(field, "ASC");
   }
 
   /**
    * Alias for {@link Search.sortDescending}.
    */
   sortDesc(field: EntityKeys<T>): AbstractSearch<T> {
-    return this.sortDescending(field)
+    return this.sortDescending(field);
   }
 
   /**
@@ -82,54 +83,69 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns this
    */
   sortDescending(field: EntityKeys<T>): AbstractSearch<T> {
-    return this.sortBy(field, 'DESC')
+    return this.sortBy(field, "DESC");
   }
 
   /**
    * Alias for {@link Search.sortAscending}.
    */
   sortAsc(field: EntityKeys<T>): AbstractSearch<T> {
-    return this.sortAscending(field)
+    return this.sortAscending(field);
   }
 
   /**
-     * Applies sorting for the query.
-     * @param fieldName The field to sort by.
-     * @param order The order of returned {@link Entity | Entities} Defaults to `ASC` (ascending) if not specified
-     * @returns this
-     */
-  sortBy(fieldName: EntityKeys<T>, order: 'ASC' | 'DESC' = 'ASC'): AbstractSearch<T> {
-    const field = this.schema.fieldByName(fieldName)
-    const dataStructure = this.schema.dataStructure
+   * Applies sorting for the query.
+   * @param fieldName The field to sort by.
+   * @param order The order of returned {@link Entity | Entities} Defaults to `ASC` (ascending) if not specified
+   * @returns this
+   */
+  sortBy(
+    fieldName: EntityKeys<T>,
+    order: "ASC" | "DESC" = "ASC",
+  ): AbstractSearch<T> {
+    const field = this.schema.fieldByName(fieldName);
+    const dataStructure = this.schema.dataStructure;
 
     if (!field) {
-      const message = `'sortBy' was called on field '${String(fieldName)}' which is not defined in the Schema.`
-      console.error(message)
-      throw new RedisOmError(message)
+      const message = `'sortBy' was called on field '${String(fieldName)}' which is not defined in the Schema.`;
+      console.error(message);
+      throw new RedisOmError(message);
     }
 
-    const type = field.type
-    const markedSortable = field.sortable
+    const type = field.type;
+    const markedSortable = field.sortable;
 
-    const UNSORTABLE = ['point', 'string[]']
-    const JSON_SORTABLE = ['number', 'text', 'date']
-    const HASH_SORTABLE = ['string', 'boolean', 'number', 'text', 'date']
+    const UNSORTABLE = ["point", "string[]"];
+    const JSON_SORTABLE = ["number", "text", "date"];
+    const HASH_SORTABLE = ["string", "boolean", "number", "text", "date"];
 
     if (UNSORTABLE.includes(type)) {
-      const message = `'sortBy' was called on '${field.type}' field '${field.name}' which cannot be sorted.`
-      console.error(message)
-      throw new RedisOmError(message)
+      const message = `'sortBy' was called on '${field.type}' field '${field.name}' which cannot be sorted.`;
+      console.error(message);
+      throw new RedisOmError(message);
     }
 
-    if (dataStructure === 'JSON' && JSON_SORTABLE.includes(type) && !markedSortable)
-      console.warn(`'sortBy' was called on field '${field.name}' which is not marked as sortable in the Schema. This may result is slower searches. If possible, mark the field as sortable in the Schema.`)
+    if (
+      dataStructure === "JSON" &&
+      JSON_SORTABLE.includes(type) &&
+      !markedSortable
+    )
+      console.warn(
+        `'sortBy' was called on field '${field.name}' which is not marked as sortable in the Schema. This may result is slower searches. If possible, mark the field as sortable in the Schema.`,
+      );
 
-    if (dataStructure === 'HASH' && HASH_SORTABLE.includes(type) && !markedSortable)
-      console.warn(`'sortBy' was called on field '${field.name}' which is not marked as sortable in the Schema. This may result is slower searches. If possible, mark the field as sortable in the Schema.`)
+    if (
+      dataStructure === "HASH" &&
+      HASH_SORTABLE.includes(type) &&
+      !markedSortable
+    )
+      console.warn(
+        `'sortBy' was called on field '${field.name}' which is not marked as sortable in the Schema. This may result is slower searches. If possible, mark the field as sortable in the Schema.`,
+      );
 
-    this.sortOptions = { BY: field.name, DIRECTION: order }
+    this.sortOptions = { BY: field.name, DIRECTION: order };
 
-    return this
+    return this;
   }
 
   /**
@@ -138,7 +154,7 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns The {@link Entity} with the minimal value
    */
   async min(field: EntityKeys<T>): Promise<T | null> {
-    return await this.sortBy(field, 'ASC').first()
+    return await this.sortBy(field, "ASC").first();
   }
 
   /**
@@ -147,7 +163,7 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns The entity ID with the minimal value
    */
   async minId(field: EntityKeys<T>): Promise<string | null> {
-    return await this.sortBy(field, 'ASC').firstId()
+    return await this.sortBy(field, "ASC").firstId();
   }
 
   /**
@@ -156,7 +172,7 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns The key name with the minimal value
    */
   async minKey(field: EntityKeys<T>): Promise<string | null> {
-    return await this.sortBy(field, 'ASC').firstKey()
+    return await this.sortBy(field, "ASC").firstKey();
   }
 
   /**
@@ -165,7 +181,7 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns The entity ID {@link Entity} with the maximal value
    */
   async max(field: EntityKeys<T>): Promise<T | null> {
-    return await this.sortBy(field, 'DESC').first()
+    return await this.sortBy(field, "DESC").first();
   }
 
   /**
@@ -173,8 +189,8 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @param field The field with the maximal value.
    * @returns The entity ID with the maximal value
    */
-  async maxId(field: EntityKeys<T>): Promise<string | null>{
-    return await this.sortBy(field, 'DESC').firstId()
+  async maxId(field: EntityKeys<T>): Promise<string | null> {
+    return await this.sortBy(field, "DESC").firstId();
   }
 
   /**
@@ -183,7 +199,7 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns The key name with the maximal value
    */
   async maxKey(field: EntityKeys<T>): Promise<string | null> {
-    return await this.sortBy(field, 'DESC').firstKey()
+    return await this.sortBy(field, "DESC").firstKey();
   }
 
   /**
@@ -191,8 +207,8 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns
    */
   async count(): Promise<number> {
-    const searchResults = await this.callSearch()
-    return extractCountFromSearchResults(searchResults)
+    const searchResults = await this.callSearch();
+    return extractCountFromSearchResults(searchResults);
   }
 
   /**
@@ -202,8 +218,8 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns An array of {@link Entity | Entities} matching the query.
    */
   async page(offset: number, count: number): Promise<T[]> {
-    const searchResults = await this.callSearch(offset, count)
-    return extractEntitiesFromSearchResults(this.schema, searchResults)
+    const searchResults = await this.callSearch(offset, count);
+    return extractEntitiesFromSearchResults(this.schema, searchResults);
   }
 
   /**
@@ -212,9 +228,9 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @param count The number of entity IDs to return.
    * @returns An array of strings matching the query.
    */
-   async pageOfIds(offset: number, count: number): Promise<string[]> {
-    const searchResults = await this.callSearch(offset, count, true)
-    return extractEntityIdsFromSearchResults(this.schema, searchResults)
+  async pageOfIds(offset: number, count: number): Promise<string[]> {
+    const searchResults = await this.callSearch(offset, count, true);
+    return extractEntityIdsFromSearchResults(this.schema, searchResults);
   }
 
   /**
@@ -224,32 +240,32 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns An array of strings matching the query.
    */
   async pageOfKeys(offset: number, count: number): Promise<string[]> {
-    const searchResults = await this.callSearch(offset, count, true)
-    return extractKeyNamesFromSearchResults(searchResults)
+    const searchResults = await this.callSearch(offset, count, true);
+    return extractKeyNamesFromSearchResults(searchResults);
   }
 
   /**
    * Returns the first {@link Entity} that matches this query.
    */
   async first(): Promise<T | null> {
-    const foundEntity = await this.page(0, 1)
-    return foundEntity[0] ?? null
+    const foundEntity = await this.page(0, 1);
+    return foundEntity[0] ?? null;
   }
 
   /**
    * Returns the first entity ID that matches this query.
    */
-   async firstId(): Promise<string | null> {
-    const foundIds = await this.pageOfIds(0, 1)
-    return foundIds[0] ?? null
+  async firstId(): Promise<string | null> {
+    const foundIds = await this.pageOfIds(0, 1);
+    return foundIds[0] ?? null;
   }
 
   /**
    * Returns the first key name that matches this query.
    */
-   async firstKey(): Promise<string | null> {
-    const foundKeys = await this.pageOfKeys(0, 1)
-    return foundKeys[0] ?? null
+  async firstKey(): Promise<string | null> {
+    const foundKeys = await this.pageOfKeys(0, 1);
+    return foundKeys[0] ?? null;
   }
 
   /**
@@ -267,7 +283,7 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns An array of {@link Entity | Entities} matching the query.
    */
   async all(options = { pageSize: 10 }): Promise<T[]> {
-    return this.allThings(this.page, options) as Promise<T[]>
+    return this.allThings(this.page, options) as Promise<T[]>;
   }
 
   /**
@@ -285,7 +301,7 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns An array of entity IDs matching the query.
    */
   async allIds(options = { pageSize: 10 }): Promise<string[]> {
-    return this.allThings(this.pageOfIds, options) as Promise<string[]>
+    return this.allThings(this.pageOfIds, options) as Promise<string[]>;
   }
 
   /**
@@ -303,7 +319,7 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns An array of key names matching the query.
    */
   async allKeys(options = { pageSize: 10 }): Promise<string[]> {
-    return await this.allThings(this.pageOfKeys, options) as string[]
+    return (await this.allThings(this.pageOfKeys, options)) as string[];
   }
 
   /**
@@ -311,164 +327,172 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
    * @returns this
    */
   get return(): AbstractSearch<T> {
-    return this
+    return this;
   }
 
   /**
    * Alias for {@link Search.min}.
    */
   async returnMin(field: EntityKeys<T>): Promise<T | null> {
-    return await this.min(field)
+    return await this.min(field);
   }
 
   /**
    * Alias for {@link Search.minId}.
    */
   async returnMinId(field: EntityKeys<T>): Promise<string | null> {
-    return await this.minId(field)
+    return await this.minId(field);
   }
 
   /**
    * Alias for {@link Search.minKey}.
    */
   async returnMinKey(field: EntityKeys<T>): Promise<string | null> {
-    return await this.minKey(field)
+    return await this.minKey(field);
   }
 
   /**
    * Alias for {@link Search.max}.
    */
   async returnMax(field: EntityKeys<T>): Promise<T | null> {
-    return await this.max(field)
+    return await this.max(field);
   }
 
   /**
    * Alias for {@link Search.maxId}.
    */
   async returnMaxId(field: EntityKeys<T>): Promise<string | null> {
-    return await this.maxId(field)
+    return await this.maxId(field);
   }
 
   /**
    * Alias for {@link Search.maxKey}.
    */
   async returnMaxKey(field: EntityKeys<T>): Promise<string | null> {
-    return await this.maxKey(field)
+    return await this.maxKey(field);
   }
 
   /**
    * Alias for {@link Search.count}.
    */
   async returnCount(): Promise<number> {
-    return await this.count()
+    return await this.count();
   }
 
   /**
    * Alias for {@link Search.page}.
    */
   async returnPage(offset: number, count: number): Promise<T[]> {
-    return await this.page(offset, count)
+    return await this.page(offset, count);
   }
 
   /**
    * Alias for {@link Search.pageOfIds}.
    */
   async returnPageOfIds(offset: number, count: number): Promise<string[]> {
-    return await this.pageOfIds(offset, count)
+    return await this.pageOfIds(offset, count);
   }
 
   /**
    * Alias for {@link Search.pageOfKeys}.
    */
   async returnPageOfKeys(offset: number, count: number): Promise<string[]> {
-    return await this.pageOfKeys(offset, count)
+    return await this.pageOfKeys(offset, count);
   }
 
   /**
    * Alias for {@link Search.first}.
    */
   async returnFirst(): Promise<T | null> {
-    return await this.first()
+    return await this.first();
   }
 
   /**
    * Alias for {@link Search.firstId}.
    */
   async returnFirstId(): Promise<string | null> {
-    return await this.firstId()
+    return await this.firstId();
   }
 
   /**
    * Alias for {@link Search.firstKey}.
    */
   async returnFirstKey(): Promise<string | null> {
-    return await this.firstKey()
+    return await this.firstKey();
   }
 
   /**
    * Alias for {@link Search.all}.
    */
-   async returnAll(options = { pageSize: 10 }): Promise<T[]> {
-    return await this.all(options)
+  async returnAll(options = { pageSize: 10 }): Promise<T[]> {
+    return await this.all(options);
   }
 
   /**
    * Alias for {@link Search.allIds}.
    */
   async returnAllIds(options = { pageSize: 10 }): Promise<string[]> {
-    return await this.allIds(options)
+    return await this.allIds(options);
   }
 
   /**
    * Alias for {@link Search.allKeys}.
    */
   async returnAllKeys(options = { pageSize: 10 }): Promise<string[]> {
-    return await this.allKeys(options)
+    return await this.allKeys(options);
   }
 
-  private async allThings(pageFn: Function, options = { pageSize: 10 }): Promise<T[] | string[]> {
-    const things = []
-    let offset = 0
-    const pageSize = options.pageSize
+  private async allThings(
+    pageFn: Function,
+    options = { pageSize: 10 },
+  ): Promise<T[] | string[]> {
+    const things = [];
+    let offset = 0;
+    const pageSize = options.pageSize;
 
     while (true) {
-      const foundThings = await pageFn.call(this, offset, pageSize)
-      things.push(...foundThings)
-      if (foundThings.length < pageSize) break
-      offset += pageSize
+      const foundThings = await pageFn.call(this, offset, pageSize);
+      things.push(...foundThings);
+      if (foundThings.length < pageSize) break;
+      offset += pageSize;
     }
 
-    return things
+    return things;
   }
 
-  private async callSearch(offset = 0, count = 0, keysOnly = false): Promise<SearchResults> {
-
-    const dataStructure = this.schema.dataStructure
-    const indexName = this.schema.indexName
-    const query = this.query
+  private async callSearch(
+    offset = 0,
+    count = 0,
+    keysOnly = false,
+  ): Promise<SearchResults> {
+    const dataStructure = this.schema.dataStructure;
+    const indexName = this.schema.indexName;
+    const query = this.query;
     const options: SearchOptions = {
-      LIMIT: { from: offset, size: count }
-    }
+      LIMIT: { from: offset, size: count },
+    };
 
-    if (this.sortOptions !== undefined) options.SORTBY = this.sortOptions
+    if (this.sortOptions !== undefined) options.SORTBY = this.sortOptions;
 
     if (keysOnly) {
-      options.RETURN = []
-    } else if (dataStructure === 'JSON') {
-      options.RETURN = '$'
+      options.RETURN = [];
+    } else if (dataStructure === "JSON") {
+      options.RETURN = "$";
     }
 
-    let searchResults
+    let searchResults;
     try {
-      searchResults = await this.client.search(indexName, query, options)
+      searchResults = await this.client.search(indexName, query, options);
     } catch (error) {
-      const message = (error as Error).message
+      const message = (error as Error).message;
       if (message.startsWith("Syntax error")) {
-        throw new SearchError(`The query to RediSearch had a syntax error: "${message}".\nThis is often the result of using a stop word in the query. Either change the query to not use a stop word or change the stop words in the schema definition. You can check the RediSearch source for the default stop words at: https://github.com/RediSearch/RediSearch/blob/master/src/stopwords.h.`)
+        throw new SearchError(
+          `The query to RediSearch had a syntax error: "${message}".\nThis is often the result of using a stop word in the query. Either change the query to not use a stop word or change the stop words in the schema definition. You can check the RediSearch source for the default stop words at: https://github.com/RediSearch/RediSearch/blob/master/src/stopwords.h.`,
+        );
       }
-      throw error
+      throw error;
     }
-    return searchResults
+    return searchResults;
   }
 }
 
@@ -478,34 +502,37 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
  * installed.
  * @template TEntity The type of {@link Entity} being sought.
  */
-export class RawSearch<T extends Entity = Record<string, any>> extends AbstractSearch<T> {
-  private readonly rawQuery: string
+export class RawSearch<
+  T extends Entity = Record<string, any>,
+> extends AbstractSearch<T> {
+  private readonly rawQuery: string;
 
   /** @internal */
-  constructor(schema: Schema<T>, client: Client, query: string = '*') {
-    super(schema, client)
-    this.rawQuery = query
+  constructor(schema: Schema<T>, client: Client, query: string = "*") {
+    super(schema, client);
+    this.rawQuery = query;
   }
 
   /** @internal */
   get query(): string {
-    return this.rawQuery
+    return this.rawQuery;
   }
 }
-
 
 /**
  * Entry point to fluent search. This is the default Redis OM experience.
  * Requires that RediSearch (and optionally RedisJSON) be installed.
  * @template TEntity The type of {@link Entity} being sought.
  */
-export class Search<T extends Entity = Record<string, any>> extends AbstractSearch<T> {
-  private rootWhere?: Where
+export class Search<
+  T extends Entity = Record<string, any>,
+> extends AbstractSearch<T> {
+  private rootWhere?: Where;
 
   /** @internal */
   get query(): string {
-    if (this.rootWhere === undefined) return '*'
-    return `${this.rootWhere.toString()}`
+    if (this.rootWhere === undefined) return "*";
+    return `${this.rootWhere.toString()}`;
   }
 
   /**
@@ -514,7 +541,7 @@ export class Search<T extends Entity = Record<string, any>> extends AbstractSear
    * @param field The field to filter on.
    * @returns A subclass of {@link WhereField} matching the type of the field.
    */
-  where(field: EntityKeys<T>): WhereField<T>
+  where(field: EntityKeys<T>): WhereField<T>;
 
   /**
    * Sets up a nested search. If there are multiple calls to {@link Search.where},
@@ -522,9 +549,11 @@ export class Search<T extends Entity = Record<string, any>> extends AbstractSear
    * @param subSearchFn A function that takes a {@link Search} and returns another {@link Search}.
    * @returns `this`.
    */
-  where(subSearchFn: SubSearchFunction<T>): Search<T>
-  where(fieldOrFn: EntityKeys<T> | SubSearchFunction<T>): WhereField<T> | Search<T> {
-    return this.anyWhere(WhereAnd, fieldOrFn)
+  where(subSearchFn: SubSearchFunction<T>): Search<T>;
+  where(
+    fieldOrFn: EntityKeys<T> | SubSearchFunction<T>,
+  ): WhereField<T> | Search<T> {
+    return this.anyWhere(WhereAnd, fieldOrFn);
   }
 
   /**
@@ -532,16 +561,18 @@ export class Search<T extends Entity = Record<string, any>> extends AbstractSear
    * @param field The field to filter on.
    * @returns A subclass of {@link WhereField} matching the type of the field.
    */
-  and(field: EntityKeys<T>): WhereField<T>
+  and(field: EntityKeys<T>): WhereField<T>;
 
   /**
    * Sets up a nested search as a logical AND.
    * @param subSearchFn A function that takes a {@link Search} and returns another {@link Search}.
    * @returns `this`.
    */
-  and(subSearchFn: SubSearchFunction<T>): Search<T>
-  and(fieldOrFn: EntityKeys<T> | SubSearchFunction<T>): WhereField<T> | Search<T> {
-    return this.anyWhere(WhereAnd, fieldOrFn)
+  and(subSearchFn: SubSearchFunction<T>): Search<T>;
+  and(
+    fieldOrFn: EntityKeys<T> | SubSearchFunction<T>,
+  ): WhereField<T> | Search<T> {
+    return this.anyWhere(WhereAnd, fieldOrFn);
   }
 
   /**
@@ -549,71 +580,88 @@ export class Search<T extends Entity = Record<string, any>> extends AbstractSear
    * @param field The field to filter on.
    * @returns A subclass of {@link WhereField} matching the type of the field.
    */
-  or(field: EntityKeys<T>): WhereField<T>
+  or(field: EntityKeys<T>): WhereField<T>;
 
   /**
    * Sets up a nested search as a logical OR.
    * @param subSearchFn A function that takes a {@link Search} and returns another {@link Search}.
    * @returns `this`.
    */
-  or(subSearchFn: SubSearchFunction<T>): Search<T>
-  or(fieldOrFn: EntityKeys<T> | SubSearchFunction<T>): WhereField<T> | Search<T> {
-    return this.anyWhere(WhereOr, fieldOrFn)
+  or(subSearchFn: SubSearchFunction<T>): Search<T>;
+  or(
+    fieldOrFn: EntityKeys<T> | SubSearchFunction<T>,
+  ): WhereField<T> | Search<T> {
+    return this.anyWhere(WhereOr, fieldOrFn);
   }
 
-  private anyWhere(ctor: AndOrConstructor, fieldOrFn: EntityKeys<T> | SubSearchFunction<T>): WhereField<T> | Search<T> {
-    if (typeof fieldOrFn === 'function') {
-      return this.anyWhereForFunction(ctor, fieldOrFn)
+  private anyWhere(
+    ctor: AndOrConstructor,
+    fieldOrFn: EntityKeys<T> | SubSearchFunction<T>,
+  ): WhereField<T> | Search<T> {
+    if (typeof fieldOrFn === "function") {
+      return this.anyWhereForFunction(ctor, fieldOrFn);
     } else {
-      return this.anyWhereForField(ctor, fieldOrFn)
+      return this.anyWhereForField(ctor, fieldOrFn);
     }
   }
 
-  private anyWhereForField(ctor: AndOrConstructor, field: EntityKeys<T>): WhereField<T> {
-    const where = this.createWhere(field)
+  private anyWhereForField(
+    ctor: AndOrConstructor,
+    field: EntityKeys<T>,
+  ): WhereField<T> {
+    const where = this.createWhere(field);
 
     if (this.rootWhere === undefined) {
-      this.rootWhere = where
+      this.rootWhere = where;
     } else {
-      this.rootWhere = new ctor(this.rootWhere, where)
+      this.rootWhere = new ctor(this.rootWhere, where);
     }
 
-    return where
+    return where;
   }
 
-  private anyWhereForFunction(ctor: AndOrConstructor, subSearchFn: SubSearchFunction<T>): Search<T> {
-    const search = new Search(this.schema, this.client)
-    const subSearch = subSearchFn(search)
+  private anyWhereForFunction(
+    ctor: AndOrConstructor,
+    subSearchFn: SubSearchFunction<T>,
+  ): Search<T> {
+    const search = new Search(this.schema, this.client);
+    const subSearch = subSearchFn(search);
 
     if (subSearch.rootWhere === undefined) {
-      throw new SearchError("Sub-search without a root where was somehow defined.")
+      throw new SearchError(
+        "Sub-search without a root where was somehow defined.",
+      );
     } else {
       if (this.rootWhere === undefined) {
-        this.rootWhere = subSearch.rootWhere
+        this.rootWhere = subSearch.rootWhere;
       } else {
-        this.rootWhere = new ctor(this.rootWhere, subSearch.rootWhere)
+        this.rootWhere = new ctor(this.rootWhere, subSearch.rootWhere);
       }
     }
 
-    return this
+    return this;
   }
 
   private createWhere(fieldName: EntityKeys<T>): WhereField<T> {
-    const field = this.schema.fieldByName(fieldName)
+    const field = this.schema.fieldByName(fieldName);
 
-    if (field === null) throw new FieldNotInSchema(String(fieldName))
+    if (field === null) throw new FieldNotInSchema(String(fieldName));
 
-    if (field.type === 'boolean' && this.schema.dataStructure === 'HASH') return new WhereHashBoolean(this, field)
-    if (field.type === 'boolean' && this.schema.dataStructure === 'JSON') return new WhereJsonBoolean(this, field)
-    if (field.type === 'date') return new WhereDate(this, field)
-    if (field.type === 'number') return new WhereNumber(this, field)
-    if (field.type === 'number[]') return new WhereNumber(this, field)
-    if (field.type === 'point') return new WherePoint(this, field)
-    if (field.type === 'text') return new WhereText(this, field)
-    if (field.type === 'string') return new WhereString(this, field)
-    if (field.type === 'string[]') return new WhereStringArray(this, field)
+    if (field.type === "boolean" && this.schema.dataStructure === "HASH")
+      return new WhereHashBoolean(this, field);
+    if (field.type === "boolean" && this.schema.dataStructure === "JSON")
+      return new WhereJsonBoolean(this, field);
+    if (field.type === "date") return new WhereDate(this, field);
+    if (field.type === "number") return new WhereNumber(this, field);
+    if (field.type === "number[]") return new WhereNumber(this, field);
+    if (field.type === "point") return new WherePoint(this, field);
+    if (field.type === "text") return new WhereText(this, field);
+    if (field.type === "string") return new WhereString(this, field);
+    if (field.type === "string[]") return new WhereStringArray(this, field);
 
-    // @ts-ignore: This is a trap for JavaScript
-    throw new RedisOmError(`The field type of '${fieldDef.type}' is not a valid field type. Valid types include 'boolean', 'date', 'number', 'point', 'string', and 'string[]'.`)
+    throw new RedisOmError(
+      // @ts-ignore: This is a trap for JavaScript
+      `The field type of '${fieldDef.type}' is not a valid field type. Valid types include 'boolean', 'date', 'number', 'point', 'string', and 'string[]'.`,
+    );
   }
 }

--- a/lib/search/search.ts
+++ b/lib/search/search.ts
@@ -1,23 +1,28 @@
-import { SearchOptions } from "redis"
+import {SearchOptions} from "redis"
 
-import { Client, SearchResults } from "../client"
-import { Entity, EntityKeys } from '../entity'
-import { Schema } from "../schema"
+import {Client, SearchResults} from "../client"
+import {Entity, EntityKeys} from '../entity'
+import {Schema} from "../schema"
 
-import { Where } from './where'
-import { WhereAnd } from './where-and'
-import { WhereOr } from './where-or'
-import { WhereField } from './where-field'
-import { WhereStringArray } from './where-string-array'
-import { WhereHashBoolean, WhereJsonBoolean } from './where-boolean'
-import { WhereNumber } from './where-number'
-import { WherePoint } from './where-point'
-import { WhereString } from './where-string'
-import { WhereText } from './where-text'
+import {Where} from './where'
+import {WhereAnd} from './where-and'
+import {WhereOr} from './where-or'
+import {WhereField} from './where-field'
+import {WhereStringArray} from './where-string-array'
+import {WhereHashBoolean, WhereJsonBoolean} from './where-boolean'
+import {WhereNumber} from './where-number'
+import {WherePoint} from './where-point'
+import {WhereString} from './where-string'
+import {WhereText} from './where-text'
 
-import { extractCountFromSearchResults, extractEntitiesFromSearchResults, extractEntityIdsFromSearchResults, extractKeyNamesFromSearchResults } from "./results-converter"
-import { FieldNotInSchema, RedisOmError, SearchError } from "../error"
-import { WhereDate } from "./where-date"
+import {
+  extractCountFromSearchResults,
+  extractEntitiesFromSearchResults,
+  extractEntityIdsFromSearchResults,
+  extractKeyNamesFromSearchResults
+} from "./results-converter"
+import {FieldNotInSchema, RedisOmError, SearchError} from "../error"
+import {WhereDate} from "./where-date"
 
 /**
  * A function that takes a {@link Search} and returns a {@link Search}. Used in nested queries.
@@ -98,7 +103,7 @@ export abstract class AbstractSearch<T extends Entity = Record<string, any>> {
     const dataStructure = this.schema.dataStructure
 
     if (!field) {
-      const message = `'sortBy' was called on field '${fieldName}' which is not defined in the Schema.`
+      const message = `'sortBy' was called on field '${String(fieldName)}' which is not defined in the Schema.`
       console.error(message)
       throw new RedisOmError(message)
     }
@@ -557,10 +562,10 @@ export class Search<T extends Entity = Record<string, any>> extends AbstractSear
   }
 
   private anyWhere(ctor: AndOrConstructor, fieldOrFn: EntityKeys<T> | SubSearchFunction<T>): WhereField<T> | Search<T> {
-    if (typeof fieldOrFn === 'string') {
-      return this.anyWhereForField(ctor, fieldOrFn)
-    } else {
+    if (typeof fieldOrFn === 'function') {
       return this.anyWhereForFunction(ctor, fieldOrFn)
+    } else {
+      return this.anyWhereForField(ctor, fieldOrFn)
     }
   }
 
@@ -596,7 +601,7 @@ export class Search<T extends Entity = Record<string, any>> extends AbstractSear
   private createWhere(fieldName: EntityKeys<T>): WhereField<T> {
     const field = this.schema.fieldByName(fieldName)
 
-    if (field === null) throw new FieldNotInSchema(fieldName)
+    if (field === null) throw new FieldNotInSchema(String(fieldName))
 
     if (field.type === 'boolean' && this.schema.dataStructure === 'HASH') return new WhereHashBoolean(this, field)
     if (field.type === 'boolean' && this.schema.dataStructure === 'JSON') return new WhereJsonBoolean(this, field)

--- a/lib/search/where-boolean.ts
+++ b/lib/search/where-boolean.ts
@@ -1,31 +1,32 @@
 import { Search } from "./search"
 import { WhereField } from "./where-field"
+import {Entity} from "$lib/entity";
 
-export abstract class WhereBoolean extends WhereField {
+export abstract class WhereBoolean<T extends Entity> extends WhereField<T> {
   protected value!: boolean
 
-  eq(value: boolean): Search {
+  eq(value: boolean): Search<T> {
     this.value = value
     return this.search
   }
 
-  equal(value: boolean): Search { return this.eq(value) }
-  equals(value: boolean): Search { return this.eq(value) }
-  equalTo(value: boolean): Search { return this.eq(value) }
+  equal(value: boolean): Search<T> { return this.eq(value) }
+  equals(value: boolean): Search<T> { return this.eq(value) }
+  equalTo(value: boolean): Search<T> { return this.eq(value) }
 
-  true(): Search { return this.eq(true) }
-  false(): Search { return this.eq(false) }
+  true(): Search<T> { return this.eq(true) }
+  false(): Search<T> { return this.eq(false) }
 
   abstract toString(): string
 }
 
-export class WhereHashBoolean extends WhereBoolean {
+export class WhereHashBoolean<T extends Entity> extends WhereBoolean<T> {
   toString(): string {
     return this.buildQuery(`{${this.value ? '1' : '0'}}`)
   }
 }
 
-export class WhereJsonBoolean extends WhereBoolean {
+export class WhereJsonBoolean<T extends Entity> extends WhereBoolean<T> {
   toString(): string {
     return this.buildQuery(`{${this.value}}`)
   }

--- a/lib/search/where-date.ts
+++ b/lib/search/where-date.ts
@@ -1,62 +1,63 @@
 import { Search } from "./search"
 import { WhereField } from "./where-field"
+import {Entity} from "$lib/entity";
 
-export class WhereDate extends WhereField {
+export class WhereDate<T extends Entity> extends WhereField<T> {
   private lower: number = Number.NEGATIVE_INFINITY
   private upper: number = Number.POSITIVE_INFINITY
   private lowerExclusive: boolean = false
   private upperExclusive: boolean = false
 
-  eq(value: Date | number | string): Search {
+  eq(value: Date | number | string): Search<T> {
     const epoch = this.coerceDateToEpoch(value)
     this.lower = epoch
     this.upper = epoch
     return this.search
   }
 
-  gt(value: Date | number | string): Search {
+  gt(value: Date | number | string): Search<T> {
     const epoch = this.coerceDateToEpoch(value)
     this.lower = epoch
     this.lowerExclusive = true
     return this.search
   }
 
-  gte(value: Date | number | string): Search {
+  gte(value: Date | number | string): Search<T> {
     this.lower = this.coerceDateToEpoch(value)
     return this.search
   }
 
-  lt(value: Date | number | string): Search {
+  lt(value: Date | number | string): Search<T> {
     this.upper = this.coerceDateToEpoch(value)
     this.upperExclusive = true
     return this.search
   }
 
-  lte(value: Date | number | string): Search {
+  lte(value: Date | number | string): Search<T> {
     this.upper = this.coerceDateToEpoch(value)
     return this.search
   }
 
-  between(lower: Date | number | string, upper: Date | number | string): Search {
+  between(lower: Date | number | string, upper: Date | number | string): Search<T> {
     this.lower = this.coerceDateToEpoch(lower)
     this.upper = this.coerceDateToEpoch(upper)
     return this.search
   }
 
-  equal(value: Date | number | string): Search { return this.eq(value) }
-  equals(value: Date | number | string): Search { return this.eq(value) }
-  equalTo(value: Date | number | string): Search { return this.eq(value) }
+  equal(value: Date | number | string): Search<T> { return this.eq(value) }
+  equals(value: Date | number | string): Search<T> { return this.eq(value) }
+  equalTo(value: Date | number | string): Search<T> { return this.eq(value) }
 
-  greaterThan(value: Date | number | string): Search { return this.gt(value) }
-  greaterThanOrEqualTo(value: Date | number | string): Search { return this.gte(value) }
-  lessThan(value: Date | number | string): Search { return this.lt(value) }
-  lessThanOrEqualTo(value: Date | number | string): Search { return this.lte(value) }
+  greaterThan(value: Date | number | string): Search<T> { return this.gt(value) }
+  greaterThanOrEqualTo(value: Date | number | string): Search<T> { return this.gte(value) }
+  lessThan(value: Date | number | string): Search<T> { return this.lt(value) }
+  lessThanOrEqualTo(value: Date | number | string): Search<T> { return this.lte(value) }
 
-  on(value: Date | number | string): Search { return this.eq(value) }
-  after(value: Date | number | string): Search { return this.gt(value) }
-  before(value: Date | number | string): Search { return this.lt(value) }
-  onOrAfter(value: Date | number | string): Search { return this.gte(value) }
-  onOrBefore(value: Date | number | string): Search { return this.lte(value) }
+  on(value: Date | number | string): Search<T> { return this.eq(value) }
+  after(value: Date | number | string): Search<T> { return this.gt(value) }
+  before(value: Date | number | string): Search<T> { return this.lt(value) }
+  onOrAfter(value: Date | number | string): Search<T> { return this.gte(value) }
+  onOrBefore(value: Date | number | string): Search<T> { return this.lte(value) }
 
   toString(): string {
     const lower = this.makeLowerString()

--- a/lib/search/where-field.ts
+++ b/lib/search/where-field.ts
@@ -2,12 +2,13 @@ import { Field } from "../schema"
 import { Search } from "./search"
 import { Where } from "./where"
 import { CircleFunction } from "./where-point"
+import { Entity } from "$lib/entity";
 
 /**
  * Interface with all the methods from all the concrete
  * classes under {@link WhereField}.
  */
-export interface WhereField extends Where {
+export interface WhereField<T extends Entity = Record<string, any>> extends Where {
 
   /**
    * Adds an equals comparison to the query.
@@ -17,7 +18,7 @@ export interface WhereField extends Where {
    * @param value The value to be compared
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  eq(value: string | number | boolean | Date): Search
+  eq(value: string | number | boolean | Date): Search<T>
 
   /**
    * Adds an equals comparison to the query.
@@ -27,7 +28,7 @@ export interface WhereField extends Where {
    * @param value The value to be compared
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  equal(value: string | number | boolean | Date): Search
+  equal(value: string | number | boolean | Date): Search<T>
 
   /**
    * Adds an equals comparison to the query.
@@ -37,7 +38,7 @@ export interface WhereField extends Where {
    * @param value The value to be compared
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  equals(value: string | number | boolean | Date): Search
+  equals(value: string | number | boolean | Date): Search<T>
 
   /**
    * Adds an equals comparison to the query.
@@ -47,128 +48,130 @@ export interface WhereField extends Where {
    * @param value The value to be compared
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  equalTo(value: string | number | boolean | Date): Search
+  equalTo(value: string | number | boolean | Date): Search<T>
 
   /**
    * Adds a full-text search comparison to the query.
    * @param value The word or phrase sought.
+   * @param options
    * @param options.fuzzyMatching Whether to use fuzzy matching to find the sought word or phrase. Defaults to `false`.
    * @param options.levenshteinDistance The levenshtein distance to use for fuzzy matching. Supported values are `1`, `2`, and `3`. Defaults to `1`.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  match(value: string | number | boolean, options?: { fuzzyMatching?: boolean; levenshteinDistance?: 1 | 2 | 3 }): Search
+  match(value: string | number | boolean, options?: { fuzzyMatching?: boolean; levenshteinDistance?: 1 | 2 | 3 }): Search<T>
 
   /**
    * Adds a full-text search comparison to the query.
    * @param value The word or phrase sought.
+   * @param options
    * @param options.fuzzyMatching Whether to use fuzzy matching to find the sought word or phrase. Defaults to `false`.
    * @param options.levenshteinDistance The levenshtein distance to use for fuzzy matching. Supported values are `1`, `2`, and `3`. Defaults to `1`.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  matches(value: string | number | boolean, options?: { fuzzyMatching?: boolean; levenshteinDistance?: 1 | 2 | 3 }): Search
+  matches(value: string | number | boolean, options?: { fuzzyMatching?: boolean; levenshteinDistance?: 1 | 2 | 3 }): Search<T>
 
   /**
    * Adds a full-text search comparison to the query that matches an exact word or phrase.
    * @param value The word or phrase sought.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  matchExact(value: string | number | boolean): Search
+  matchExact(value: string | number | boolean): Search<T>
 
   /**
    * Adds a full-text search comparison to the query that matches an exact word or phrase.
    * @param value The word or phrase sought.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  matchExactly(value: string | number | boolean): Search
+  matchExactly(value: string | number | boolean): Search<T>
 
   /**
    * Adds a full-text search comparison to the query that matches an exact word or phrase.
    * @param value The word or phrase sought.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  matchesExactly(value: string | number | boolean): Search
+  matchesExactly(value: string | number | boolean): Search<T>
 
   /**
    * Makes a call to {@link WhereField.match} a {@link WhereField.matchExact} call. Calling
    * this multiple times will have no effect.
    * @returns this.
    */
-  readonly exact: WhereField
+  readonly exact: WhereField<T>
 
   /**
    * Makes a call to {@link WhereField.match} a {@link WhereField.matchExact} call. Calling
    * this multiple times will have no effect.
    * @returns this.
    */
-  readonly exactly: WhereField
+  readonly exactly: WhereField<T>
 
   /**
    * Adds a boolean match with a value of `true` to the query.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  true(): Search
+  true(): Search<T>
 
   /**
    * Adds a boolean match with a value of `false` to the query.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  false(): Search
+  false(): Search<T>
 
   /**
    * Adds a greater than comparison against a field to the search query.
    * @param value The value to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  gt(value: string | number | Date): Search
+  gt(value: string | number | Date): Search<T>
 
   /**
    * Adds a greater than comparison against a field to the search query.
    * @param value The value to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  greaterThan(value: string | number | Date): Search
+  greaterThan(value: string | number | Date): Search<T>
 
   /**
    * Adds a greater than or equal to comparison against a field to the search query.
    * @param value The value to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  gte(value: string | number | Date): Search
+  gte(value: string | number | Date): Search<T>
 
   /**
    * Adds a greater than or equal to comparison against a field to the search query.
    * @param value The value to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  greaterThanOrEqualTo(value: string | number | Date): Search
+  greaterThanOrEqualTo(value: string | number | Date): Search<T>
 
   /**
    * Adds a less than comparison against a field to the search query.
    * @param value The value to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  lt(value: string | number | Date): Search
+  lt(value: string | number | Date): Search<T>
 
   /**
    * Adds a less than comparison against a field to the search query.
    * @param value The value to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  lessThan(value: string | number | Date): Search
+  lessThan(value: string | number | Date): Search<T>
 
   /**
    * Adds a less than or equal to comparison against a field to the search query.
    * @param value The value to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  lte(value: string | number | Date): Search
+  lte(value: string | number | Date): Search<T>
 
   /**
    * Adds a less than or equal to comparison against a field to the search query.
    * @param value The value to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  lessThanOrEqualTo(value: string | number | Date): Search
+  lessThanOrEqualTo(value: string | number | Date): Search<T>
 
   /**
    * Adds an inclusive range comparison against a field to the search query.
@@ -176,21 +179,21 @@ export interface WhereField extends Where {
    * @param upper The upper bound of the range.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  between(lower: string | number | Date, upper: string | number | Date): Search
+  between(lower: string | number | Date, upper: string | number | Date): Search<T>
 
   /**
    * Adds a whole-string match for a value within a string array to the search query.
    * @param value The string to be matched.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  contain(value: string): Search
+  contain(value: string): Search<T>
 
   /**
    * Adds a whole-string match for a value within a string array to the search query.
    * @param value The string to be matched.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  contains(value: string): Search
+  contains(value: string): Search<T>
 
   /**
    * Adds a whole-string match against a string array to the query. If any of the provided
@@ -198,7 +201,7 @@ export interface WhereField extends Where {
    * @param value An array of strings that you want to match one of.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  containOneOf(...value: Array<string>): Search
+  containOneOf(...value: Array<string>): Search<T>
 
   /**
    * Adds a whole-string match against a string array to the query. If any of the provided
@@ -206,56 +209,56 @@ export interface WhereField extends Where {
    * @param value An array of strings that you want to match one of.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  containsOneOf(...value: Array<string>): Search
+  containsOneOf(...value: Array<string>): Search<T>
 
   /**
    * Adds a search for points that fall within a defined circle.
    * @param circleFn A function that returns a {@link Circle} instance defining the search area.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  inCircle(circleFn: CircleFunction): Search
+  inCircle(circleFn: CircleFunction): Search<T>
 
   /**
    * Adds a search for points that fall within a defined radius.
    * @param circleFn A function that returns a {@link Circle} instance defining the search area.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  inRadius(circleFn: CircleFunction): Search
+  inRadius(circleFn: CircleFunction): Search<T>
 
   /**
    * Add a search for an exact UTC datetime to the query.
    * @param value The datetime to match.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  on(value: string | number | Date): Search
+  on(value: string | number | Date): Search<T>
 
   /**
    * Add a search that matches all datetimes *before* the provided UTC datetime to the query.
    * @param value The datetime to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  before(value: string | number | Date): Search
+  before(value: string | number | Date): Search<T>
 
   /**
    * Add a search that matches all datetimes *after* the provided UTC datetime to the query.
    * @param value The datetime to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  after(value: string | number | Date): Search
+  after(value: string | number | Date): Search<T>
 
   /**
    * Add a search that matches all datetimes *on or before* the provided UTC datetime to the query.
    * @param value The datetime to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  onOrBefore(value: string | number | Date): Search
+  onOrBefore(value: string | number | Date): Search<T>
 
   /**
    * Add a search that matches all datetimes *on or after* the provided UTC datetime to the query.
    * @param value The datetime to compare against.
    * @returns The {@link Search} that was called to create this {@link WhereField}.
    */
-  onOrAfter(value: string | number | Date): Search
+  onOrAfter(value: string | number | Date): Search<T>
 }
 
 /**
@@ -263,17 +266,17 @@ export interface WhereField extends Where {
  * with extend. When you call {@link Search.where}, a
  * subclass of this is returned.
  */
-export abstract class WhereField {
+export abstract class WhereField<T extends Entity> {
   private negated: boolean = false
 
   /** @internal */
-  protected search: Search
+  protected search: Search<T>
 
   /** @internal */
   protected field: Field
 
   /** @internal */
-  constructor(search: Search, field: Field) {
+  constructor(search: Search<T>, field: Field) {
     this.search = search
     this.field = field
   }

--- a/lib/search/where-number.ts
+++ b/lib/search/where-number.ts
@@ -1,54 +1,55 @@
 import { Search } from "./search"
 import { WhereField } from "./where-field"
+import {Entity} from "$lib/entity";
 
-export class WhereNumber extends WhereField {
+export class WhereNumber<T extends Entity> extends WhereField<T> {
   private lower: number = Number.NEGATIVE_INFINITY
   private upper: number = Number.POSITIVE_INFINITY
   private lowerExclusive: boolean = false
   private upperExclusive: boolean = false
 
-  eq(value: number): Search {
+  eq(value: number): Search<T> {
     this.lower = value
     this.upper = value
     return this.search
   }
 
-  gt(value: number): Search {
+  gt(value: number): Search<T> {
     this.lower = value
     this.lowerExclusive = true
     return this.search
   }
 
-  gte(value: number): Search {
+  gte(value: number): Search<T> {
     this.lower = value
     return this.search
   }
 
-  lt(value: number): Search {
+  lt(value: number): Search<T> {
     this.upper = value
     this.upperExclusive = true
     return this.search
   }
 
-  lte(value: number): Search {
+  lte(value: number): Search<T> {
     this.upper = value
     return this.search
   }
 
-  between(lower: number, upper: number): Search {
+  between(lower: number, upper: number): Search<T> {
     this.lower = lower
     this.upper = upper
     return this.search
   }
 
-  equal(value: number): Search { return this.eq(value) }
-  equals(value: number): Search { return this.eq(value) }
-  equalTo(value: number): Search { return this.eq(value) }
+  equal(value: number): Search<T> { return this.eq(value) }
+  equals(value: number): Search<T> { return this.eq(value) }
+  equalTo(value: number): Search<T> { return this.eq(value) }
 
-  greaterThan(value: number): Search { return this.gt(value) }
-  greaterThanOrEqualTo(value: number): Search { return this.gte(value) }
-  lessThan(value: number): Search { return this.lt(value) }
-  lessThanOrEqualTo(value: number): Search { return this.lte(value) }
+  greaterThan(value: number): Search<T> { return this.gt(value) }
+  greaterThanOrEqualTo(value: number): Search<T> { return this.gte(value) }
+  lessThan(value: number): Search<T> { return this.lt(value) }
+  lessThanOrEqualTo(value: number): Search<T> { return this.lte(value) }
 
   toString(): string {
     const lower = this.makeLowerString()

--- a/lib/search/where-point.ts
+++ b/lib/search/where-point.ts
@@ -1,4 +1,4 @@
-import { Point } from "../entity"
+import {Entity, Point} from "../entity"
 import { Search } from "./search"
 import { WhereField } from "./where-field"
 
@@ -173,14 +173,14 @@ export class Circle {
   }
 }
 
-export class WherePoint extends WhereField {
+export class WherePoint<T extends Entity> extends WhereField<T> {
   private circle: Circle = new Circle()
 
-  inRadius(circleFn: CircleFunction): Search {
+  inRadius(circleFn: CircleFunction): Search<T> {
     return this.inCircle(circleFn)
   }
 
-  inCircle(circleFn: CircleFunction): Search {
+  inCircle(circleFn: CircleFunction): Search<T> {
     this.circle = circleFn(this.circle)
     return this.search
   }

--- a/lib/search/where-string-array.ts
+++ b/lib/search/where-string-array.ts
@@ -1,22 +1,23 @@
 import { Search } from "./search"
 import { WhereField } from "./where-field"
+import {Entity} from "$lib/entity";
 
-export class WhereStringArray extends WhereField {
+export class WhereStringArray<T extends Entity> extends WhereField<T> {
   private value!: Array<string>
 
-  contain(value: string): Search {
+  contain(value: string): Search<T> {
     this.value = [value]
     return this.search
   }
 
-  contains(value: string): Search { return this.contain(value) }
+  contains(value: string): Search<T> { return this.contain(value) }
 
-  containsOneOf(...value: Array<string>): Search {
+  containsOneOf(...value: Array<string>): Search<T> {
     this.value = value
     return this.search
   }
 
-  containOneOf(...value: Array<string>): Search { return this.containsOneOf(...value) }
+  containOneOf(...value: Array<string>): Search<T> { return this.containsOneOf(...value) }
 
   toString(): string {
     const escapedValue = this.value.map(s => this.escapePunctuationAndSpaces(s)).join('|')

--- a/lib/search/where-string.ts
+++ b/lib/search/where-string.ts
@@ -1,24 +1,25 @@
 import { Search } from "./search"
 import { WhereField } from "./where-field"
 import { SemanticSearchError } from "../error"
+import {Entity} from "$lib/entity";
 
-export class WhereString extends WhereField {
+export class WhereString<T extends Entity> extends WhereField<T> {
   private value!: string
 
-  eq(value: string | number | boolean): Search {
+  eq(value: string | number | boolean): Search<T> {
     this.value = value.toString()
     return this.search
   }
 
-  equal(value: string | number | boolean): Search { return this.eq(value) }
-  equals(value: string | number | boolean): Search { return this.eq(value) }
-  equalTo(value: string | number | boolean): Search { return this.eq(value) }
+  equal(value: string | number | boolean): Search<T> { return this.eq(value) }
+  equals(value: string | number | boolean): Search<T> { return this.eq(value) }
+  equalTo(value: string | number | boolean): Search<T> { return this.eq(value) }
 
-  match(_: string | number | boolean): Search { return this.throwMatchExcpetion() }
-  matches(_: string | number | boolean): Search { return this.throwMatchExcpetion() }
-  matchExact(_: string | number | boolean): Search { return this.throwMatchExcpetion() }
-  matchExactly(_: string | number | boolean): Search { return this.throwMatchExcpetion() }
-  matchesExactly(_: string | number | boolean): Search { return this.throwMatchExcpetion() }
+  match(_: string | number | boolean): Search<T> { return this.throwMatchExcpetion() }
+  matches(_: string | number | boolean): Search<T> { return this.throwMatchExcpetion() }
+  matchExact(_: string | number | boolean): Search<T> { return this.throwMatchExcpetion() }
+  matchExactly(_: string | number | boolean): Search<T> { return this.throwMatchExcpetion() }
+  matchesExactly(_: string | number | boolean): Search<T> { return this.throwMatchExcpetion() }
 
   get exact() { return this.throwMatchExcpetionReturningThis() }
   get exactly() { return this.throwMatchExcpetionReturningThis() }
@@ -28,11 +29,11 @@ export class WhereString extends WhereField {
     return this.buildQuery(`{${escapedValue}}`)
   }
 
-  private throwMatchExcpetion(): Search {
+  private throwMatchExcpetion(): Search<T> {
     throw new SemanticSearchError("Cannot perform full-text search operations like .match on field of type 'string'. If full-text search is needed on this field, change the type to 'text' in the Schema.")
   }
 
-  private throwMatchExcpetionReturningThis(): WhereString {
+  private throwMatchExcpetionReturningThis(): WhereString<T> {
     throw new SemanticSearchError("Cannot perform full-text search operations like .match on field of type 'string'. If full-text search is needed on this field, change the type to 'text' in the Schema.")
   }
 }

--- a/lib/search/where-text.ts
+++ b/lib/search/where-text.ts
@@ -2,8 +2,9 @@ import { Search } from "./search"
 import { WhereField } from "./where-field"
 
 import { SemanticSearchError } from "../error"
+import {Entity} from "$lib/entity";
 
-export class WhereText extends WhereField {
+export class WhereText<T extends Entity> extends WhereField<T> {
   private value!: string
   private exactValue = false
   private fuzzyMatching!: boolean
@@ -15,14 +16,14 @@ export class WhereText extends WhereField {
       fuzzyMatching: false,
       levenshteinDistance: 1,
     }
-  ): Search {
+  ): Search<T> {
     this.value = value.toString()
     this.fuzzyMatching = options.fuzzyMatching ?? false
     this.levenshteinDistance = options.levenshteinDistance ?? 1
     return this.search
   }
 
-  matchExact(value: string | number | boolean): Search {
+  matchExact(value: string | number | boolean): Search<T> {
     this.exact.value = value.toString()
     return this.search
   }
@@ -33,9 +34,9 @@ export class WhereText extends WhereField {
       fuzzyMatching: false,
       levenshteinDistance: 1,
     }
-  ): Search { return this.match(value, options) }
-  matchExactly(value: string | number | boolean): Search { return this.matchExact(value) }
-  matchesExactly(value: string | number | boolean): Search { return this.matchExact(value) }
+  ): Search<T> { return this.match(value, options) }
+  matchExactly(value: string | number | boolean): Search<T> { return this.matchExact(value) }
+  matchesExactly(value: string | number | boolean): Search<T> { return this.matchExact(value) }
 
   get exact() {
     this.exactValue = true
@@ -46,10 +47,10 @@ export class WhereText extends WhereField {
     return this.exact
   }
 
-  eq(_: string | number | boolean): Search { return this.throwEqualsExcpetion() }
-  equal(_: string | number | boolean): Search { return this.throwEqualsExcpetion() }
-  equals(_: string | number | boolean): Search { return this.throwEqualsExcpetion() }
-  equalTo(_: string | number | boolean): Search { return this.throwEqualsExcpetion() }
+  eq(_: string | number | boolean): Search<T> { return this.throwEqualsExcpetion() }
+  equal(_: string | number | boolean): Search<T> { return this.throwEqualsExcpetion() }
+  equals(_: string | number | boolean): Search<T> { return this.throwEqualsExcpetion() }
+  equalTo(_: string | number | boolean): Search<T> { return this.throwEqualsExcpetion() }
 
   toString(): string {
     const escapedValue = this.escapePunctuation(this.value)
@@ -63,7 +64,7 @@ export class WhereText extends WhereField {
     }
   }
 
-  private throwEqualsExcpetion(): Search {
+  private throwEqualsExcpetion(): Search<T> {
     throw new SemanticSearchError("Cannot call .equals on a field of type 'text', either use .match to perform full-text search or change the type to 'string' in the Schema.")
   }
 }


### PR DESCRIPTION
This pull request only modifies type declarations to allow users to add a generic type to their schemas, repositories, entities, and search. 

This will not cause any breaking changes as the default type for Entity is `Record<string, any>`