### PR TITLE
Update package.json to publish all files in dist and docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-om",
-  "version": "0.4.4",
+  "version": "0.4.6",
   "description": "Object mapping, and more, for Redis and Node.js. Written in TypeScript.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
@@ -9,8 +9,8 @@
     "CHANGELOG",
     "LICENSE",
     "logo.svg",
-    "dist/**/*",
-    "docs/**/*"
+    "dist",
+    "docs"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
Apparently using globs in package.json doesn't work anymore. Or at least not for the version of NPM I was using. Annoyingly had to bump the version number for this. Twice.