### PR TITLE
Update jsonpath-plus to 10.3.0 to Resolve Vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
-        "jsonpath-plus": "^10.1.0",
+        "jsonpath-plus": "^10.3.0",
         "just-clone": "^6.1.1",
         "redis": "^4.6.4",
         "ulid": "^2.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,10 +101,9 @@
       }
     },
     "node_modules/@jsep-plugin/assignment": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
-      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
-      "license": "MIT",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -113,10 +112,9 @@
       }
     },
     "node_modules/@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
-      "license": "MIT",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -1368,10 +1366,9 @@
       }
     },
     "node_modules/jsep": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
-      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
-      "license": "MIT",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -1383,14 +1380,13 @@
       "dev": true
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
-      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
-      "license": "MIT",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
       "dependencies": {
-        "@jsep-plugin/assignment": "^1.2.1",
-        "@jsep-plugin/regex": "^1.0.3",
-        "jsep": "^1.3.9"
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
       },
       "bin": {
         "jsonpath": "bin/jsonpath-cli.js",
@@ -2742,15 +2738,15 @@
       }
     },
     "@jsep-plugin/assignment": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
-      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
       "requires": {}
     },
     "@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {
@@ -3584,9 +3580,9 @@
       "dev": true
     },
     "jsep": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
-      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="
     },
     "jsonc-parser": {
       "version": "3.2.0",
@@ -3595,13 +3591,13 @@
       "dev": true
     },
     "jsonpath-plus": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
-      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
       "requires": {
-        "@jsep-plugin/assignment": "^1.2.1",
-        "@jsep-plugin/regex": "^1.0.3",
-        "jsep": "^1.3.9"
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
       }
     },
     "just-clone": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "vitest": "^0.20.0"
   },
   "dependencies": {
-    "jsonpath-plus": "^10.1.0",
+    "jsonpath-plus": "^10.3.0",
     "just-clone": "^6.1.1",
     "redis": "^4.6.4",
     "ulid": "^2.3.0"


### PR DESCRIPTION
This PR updates `jsonpath-plus` to v10.3.0 resolve a potential vulnerability for remote code execution ([source](https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-7945884)) and close #258.